### PR TITLE
Provide the policy rpm in Bugzilla bug reports

### DIFF
--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -966,7 +966,8 @@ class BugReport:
                                                 "setroubleshoot", 
                                                 self.alert.get_hash(), 
                                                 self.summary, 
-                                                content)
+                                                content,
+                                                package=self.alert.get_policy_rpm())
  
         try:
             rc = report.report(signature, report.io.GTKIO.GTKIO(self.parent.accounts))

--- a/framework/src/setroubleshoot/signature.py
+++ b/framework/src/setroubleshoot/signature.py
@@ -295,6 +295,9 @@ class SEFaultSignatureInfo(XmlSerialize):
         for name in self.merge_include:
             setattr(self, name, getattr(siginfo, name))
 
+    def get_policy_rpm(self):
+        return self.environment.policy_rpm;
+
     def get_hash_str(self):
         return  "%s,%s,%s,%s,%s" % (self.source, self.scontext.type, self.tcontext.type, self.tclass, ",".join(self.sig.access))
 


### PR DESCRIPTION
This patch adds the policy rpm string to the user comments of an already
reported bug.

Every comment will contain the following string:

```
Version-Release number of selected component:
selinux-policy-X.XX.X-XXX.YYY.noarch
```

Red Hat Bugzilla: #1075452
Requires: libreport >= 2.2.2
libreport commit c336fd29a62c3c772957925910a9a2e8e257f88f

Signed-off-by: Jakub Filak jfilak@redhat.com
