### PR TITLE
setroubleshootd: run server with setroubleshoot uid instead of root

### DIFF
--- a/framework/org.fedoraproject.SetroubleshootFixit.conf
+++ b/framework/org.fedoraproject.SetroubleshootFixit.conf
@@ -14,7 +14,7 @@
        authorization is performed by PolicyKit -->
   <policy context="default">
     <allow send_destination="org.fedoraproject.SetroubleshootFixit"
-	   send_interface="org.freedesktop.DBus.Introspectable"/>
+	   send_interface="org.fedoraproject.SetroubleshootFixit"/>
   </policy>
 
 </busconfig>

--- a/framework/org.fedoraproject.Setroubleshootd.conf
+++ b/framework/org.fedoraproject.Setroubleshootd.conf
@@ -4,8 +4,10 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-	<policy user="root">
+	<policy user="setroubleshoot">
 		<allow own="org.fedoraproject.Setroubleshootd"/>
+	</policy>
+	<policy user="root">
 		<allow send_destination="org.fedoraproject.Setroubleshootd"/>
 	</policy>
 	<policy context="default">

--- a/framework/org.fedoraproject.Setroubleshootd.service
+++ b/framework/org.fedoraproject.Setroubleshootd.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.fedoraproject.Setroubleshootd
 Exec=/usr/sbin/setroubleshootd -f 
-User=root
+User=setroubleshoot

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -548,7 +548,7 @@ def RunFaultServer(timeout=10):
         
         database_filename = get_config('database','filename')
         database_filepath = make_database_filepath(database_filename)
-        assure_file_ownership_permissions(database_filepath, 0600, 'root', 'root')
+        assure_file_ownership_permissions(database_filepath, 0600, 'setroubleshoot')
         host_database = SETroubleshootDatabase(database_filepath, database_filename,
                                                friendly_name=_("Audit Listener"))
         host_database.set_notify(client_notifier)
@@ -607,7 +607,7 @@ def RunFaultServer(timeout=10):
         # Initialize the email recipient list
         from setroubleshoot.signature import SEEmailRecipientSet
         email_recipients = SEEmailRecipientSet()
-        assure_file_ownership_permissions(email_recipients_filepath, 0600, 'root', 'root')
+        assure_file_ownership_permissions(email_recipients_filepath, 0600, 'setroubleshoot')
         try:
             email_recipients.parse_recipient_file(email_recipients_filepath)
         except ProgramError, e:

--- a/framework/src/setroubleshoot/util.py
+++ b/framework/src/setroubleshoot/util.py
@@ -375,7 +375,7 @@ def assure_file_ownership_permissions(filepath, mode, owner, group=None):
             f.close()
         except Exception, e:
             result = False
-            syslog.syslog(syslog.LOG_ERR, "cannot create file %s [%s]" % filepath, e.strerror)
+            syslog.syslog(syslog.LOG_ERR, "cannot create file %s [%s]" % (filepath, e.strerror))
     
     try:
         os.chmod(filepath, mode)


### PR DESCRIPTION
setroubleshootd doesn't really need to be run with root privileges. This patch changes code and dbus service setting to run setroubleshoot with setrbleshoot user. 

There's available a patch for Fedora dist-git [1]. The patch also changes the spec file to create setroubleshoot user, change owner of /var/lib/setroubleshoot and /var/run/setroubleshoot and add tmpfiles.d configation file to create /run/setroubleshoot directory on boot.

[1] https://plautrba.fedorapeople.org/setroubleshoot/setroubleshootd-run-server-with-setroubleshoot-uid-i.patch 
src.rpm is available at https://plautrba.fedorapeople.org/setroubleshoot/setroubleshoot-3.2.22-2.fc23.2.src.rpm