### PR TITLE
Update restorecon_source.py plugin to identify the current mislabeling of executable

### DIFF
--- a/plugins/src/restorecon_source.py
+++ b/plugins/src/restorecon_source.py
@@ -80,7 +80,9 @@ class plugin(Plugin):
         try:
             mcon = selinux.matchpathcon(avc.spath.strip('"'), S_IFREG)[1]
             mcon_type=mcon.split(":")[2]
-            if mcon_type != avc.scontext.type:
+            gcon = selinux.getfilecon(avc.spath.strip('"'))[1]
+            gcon_type = gcon.split(":")[2]
+            if mcon_type != gcon_type:
                 return self.report((0, mcon_type))
         except OSError:
             pass


### PR DESCRIPTION
Without this fix, the restorecon_source plugin was incorrectly applied on AVCs where a path to executable was present together with _scon_. But it did not reflect the actual label of the executable on the system.

        type=AVC msg=audit(1439912642.550:1348): avc:  denied  { read } for  pid=11718 comm="tmux" name="framework" dev="dm-3" ino=1319655 scontext=staff_u:staff_r:staff_screen_t:s0 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=1

        type=SYSCALL msg=audit(1439912642.550:1348): arch=x86_64 syscall=open success=yes exit=EINVAL a0=1616320 a1=10000 a2=1616320 a3=1 items=1 ppid=1 pid=11718 auid=13558 uid=13558 gid=1000 euid=13558 suid=13558 fsuid=13558 egid=1000 sgid=1000 fsgid=1000 tty=(none) ses=3 comm=tmux exe=/usr/bin/tmux subj=staff_u:staff_r:staff_screen_t:s0 key=(null)

The updated restorecon_source plugin reflect the current labeling on a system against a default labeling of the executable.

How to test:

         chcon -t bin_t `which tmux`
         sealert -a /tmp/the_log_above

And you should get

        *****  Plugin restorecon_source (99.5 confidence) suggests   *****************

        If you want to fix the label. 
        /usr/bin/tmux default label should be screen_exec_t.
        Then you can run restorecon.
        Do
        # /sbin/restorecon -v /usr/bin/tmux