### PR TITLE
plugins: Text and whitespace fixes

### DIFF
--- a/plugins/src/allow_anon_write.py
+++ b/plugins/src/allow_anon_write.py
@@ -41,8 +41,8 @@ class plugin(Plugin):
     "setsebool -P $BOOLEAN=1; chcon -t public_content_rw_t <path>"
     You must also change the default file context labeling files on the system in order to preserve public directory labeling even on a full relabel.  "semanage fcontext -a -t public_content_rw_t <path>"
     ''')
-    if_text = _("you want to allow $SOURCE_PATH to be able to write to shared public content")
-    then_text = _("you need to change the label on $TARGET_PATH to public_content_rw_t, and potentially turn on the allow_httpd_sys_script_anon_write boolean.")
+    if_text = _("You want to allow $SOURCE_PATH to be able to write to shared public content.")
+    then_text = _("You need to change the label on $TARGET_PATH to public_content_rw_t, and potentially turn on the allow_httpd_sys_script_anon_write boolean.")
 
     def get_do_text(self, avc, args):
         do_text = """# semanage fcontext -a -t public_content_rw_t $TARGET_PATH

--- a/plugins/src/allow_execheap.py
+++ b/plugins/src/allow_execheap.py
@@ -28,7 +28,7 @@ class plugin(Plugin):
     SELinux is preventing $SOURCE_PATH from changing the access
     protection of memory on the heap.
     ''')
-    
+
     problem_description = _('''
     The $SOURCE application attempted to change the access protection of memory on
     the heap (e.g., allocated using malloc).  This is a potential security
@@ -46,14 +46,14 @@ class plugin(Plugin):
     $BOOLEAN boolean.  Note: This boolean will affect all applications
     on the system.
     ''')
-    
-    if_text = _("you do not think $SOURCE_PATH should need to map heap memory that is both writable and executable.")
-    then_text = _("you need to report a bug. This is a potentially dangerous access.")
+
+    if_text = _("You do not think $SOURCE_PATH should need to map heap memory that is both writable and executable.")
+    then_text = _("You need to report a bug. This is a potentially dangerous access.")
     do_text = _("Contact your security administrator and report this issue.")
 
     def __init__(self):
         Plugin.__init__(self, __name__)
-        
+
     def analyze(self, avc):
         if avc.has_any_access_in(['execheap']):
             return self.report()

--- a/plugins/src/allow_execmod.py
+++ b/plugins/src/allow_execmod.py
@@ -29,7 +29,7 @@ class plugin(Plugin):
     summary =_('''
     SELinux is preventing $SOURCE_PATH from loading $TARGET_PATH which requires text relocation.
     ''')
-    
+
     problem_description = _('''
     The $SOURCE application attempted to load $TARGET_PATH which
     requires text relocation.  This is a potential security problem.
@@ -38,39 +38,39 @@ class plugin(Plugin):
     <a href="http://people.redhat.com/drepper/selinux-mem.html">SELinux Memory Protection Tests</a>
     web page explains how to remove this requirement.  You can configure
     SELinux temporarily to allow $TARGET_PATH to use relocation as a
-    workaround, until the library is fixed. Please file a 
+    workaround, until the library is fixed. Please file a
 bug report.
     ''')
-    
+
     unsafe_problem_description = _('''
     The $SOURCE application attempted to load $TARGET_PATH which
     requires text relocation.  This is a potential security problem.
-    Most libraries should not need this permission.   The   
+    Most libraries should not need this permission.   The
     <a href="http://people.redhat.com/drepper/selinux-mem.html">
     SELinux Memory Protection Tests</a>
-    web page explains this check.  This tool examined the library and it looks 
-    like it was built correctly. So setroubleshoot can not determine if this 
-    application is compromized or not.  This could be a serious issue. Your 
+    web page explains this check.  This tool examined the library and it looks
+    like it was built correctly. So setroubleshoot can not determine if this
+    application is compromized or not.  This could be a serious issue. Your
     system may very well be compromised.
 
     Contact your security administrator and report this issue.
 
     ''')
-    
-    unsafe_fix_description = "Contact your security administrator and report this issue." 
+
+    unsafe_fix_description = "Contact your security administrator and report this issue."
 
     fix_description = _('''
     If you trust $TARGET_PATH to run correctly, you can change the
     file context to textrel_shlib_t. "chcon -t textrel_shlib_t
     '$TARGET_PATH'"
     You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t textrel_shlib_t '$FIX_TARGET_PATH'"
-    
+
     ''')
 
     unsafe_then_text = """
 setroubleshoot examined '$FIX_TARGET_PATH' to make sure it was built correctly, but can not determine if this application has been compromized.  This alert could be a serious issue and your system could be compromised.
 """
-    unsafe_do_text = "Contact your security administrator and report this issue." 
+    unsafe_do_text = "Contact your security administrator and report this issue."
 
     then_text = "You need to change the label on '$FIX_TARGET_PATH'"
     do_text = """# semanage fcontext -a -t textrel_shlib_t '$FIX_TARGET_PATH'

--- a/plugins/src/allow_execstack.py
+++ b/plugins/src/allow_execstack.py
@@ -53,7 +53,7 @@ class plugin(Plugin):
     summary =_('''
     SELinux is preventing $SOURCE_PATH from making the program stack executable.
     ''')
-    
+
     problem_description = _('''
     The $SOURCE application attempted to make its stack
     executable.  This is a potential security problem.  This should
@@ -65,22 +65,22 @@ class plugin(Plugin):
     <a href="http://people.redhat.com/drepper/selinux-mem.html">SELinux Memory Protection Tests</a>
     web page explains how to remove this requirement.  If $SOURCE does not
     work and you need it to work, you can configure SELinux
-    temporarily to allow this access until the application is fixed. Please 
+    temporarily to allow this access until the application is fixed. Please
 file a bug report.
     ''')
-    
+
     fix_description = _('''
     Sometimes a library is accidentally marked with the execstack flag,
     if you find a library with this flag you can clear it with the
     execstack -c LIBRARY_PATH.  Then retry your application.  If the
     app continues to not work, you can turn the flag back on with
-    execstack -s LIBRARY_PATH.  
+    execstack -s LIBRARY_PATH.
     ''')
 
     fix_cmd = ""
 
-    if_text = _("you do not think $SOURCE_PATH should need to map stack memory that is both writable and executable.")
-    then_text = _("you need to report a bug. \nThis is a potentially dangerous access.")
+    if_text = _("You do not think $SOURCE_PATH should need to map stack memory that is both writable and executable.")
+    then_text = _("You need to report a bug. \nThis is a potentially dangerous access.")
     do_text = _("Contact your security administrator and report this issue.")
 
     def get_if_text(self, avc, args):
@@ -89,25 +89,25 @@ file a bug report.
             if not path:
                 return self.if_text
 
-            return _("you believe that \n%s\nshould not require execstack") % path
+            return _("You believe that \n%s\nshould not require execstack.") % path
         except:
             return self.if_text
-        
+
     def get_then_text(self, avc, args):
         try:
             path = args[0]
             if not path:
                 return self.then_text
-            return _("you should clear the execstack flag and see if $SOURCE_PATH works correctly.\nReport this as a bug on %s.\nYou can clear the exestack flag by executing:") % path
+            return _("You should clear the execstack flag and see if $SOURCE_PATH works correctly.\nReport this as a bug on %s.\nYou can clear the exestack flag by executing:") % path
         except:
             return self.then_text
-        
+
     def get_do_text(self, avc, args):
         try:
             path = args[0]
             if not path:
                 return self.do_text
-            
+
             return _("execstack -c %s") % path
         except:
             return self.do_text

--- a/plugins/src/allow_ftpd_use_cifs.py
+++ b/plugins/src/allow_ftpd_use_cifs.py
@@ -29,7 +29,7 @@ class plugin(Plugin):
     summary = _('''
     SELinux prevented the ftp daemon from $ACCESS files stored on a CIFS filesystem.
     ''')
-    
+
     problem_description = _('''
     SELinux prevented the ftp daemon from $ACCESS files stored on a CIFS filesystem.
     CIFS (Comment Internet File System) is a network filesystem similar to
@@ -38,7 +38,7 @@ class plugin(Plugin):
     a mounted filesystem of this type.  As CIFS filesystems do not support
     fine-grained SELinux labeling, all files and directories in the
     filesystem will have the same security context.
-    
+
     If you have not configured the ftp daemon to read files from a CIFS filesystem
     this access attempt could signal an intrusion attempt.
     ''')
@@ -47,7 +47,7 @@ class plugin(Plugin):
     Changing the "$BOOLEAN" boolean to true will allow this access:
     "setsebool -P $BOOLEAN=1."
     ''')
-    
+
     fix_cmd = 'setsebool -P $BOOLEAN=1'
 
     rw_fix_description = _(''' Changing the "$BOOLEAN" and
@@ -57,10 +57,10 @@ class plugin(Plugin):
     allow the ftp daemon to write to all public content (files and
     directories with type public_content_t) in addition to writing to
     files and directories on CIFS filesystems.  ''')
-    
+
     rw_fix_cmd = 'setsebool -P $BOOLEAN=1 $WRITE_BOOLEAN=1'
-    if_text = _("you want to allow ftpd to write to cifs file systems")
-    then_text = _("you must tell SELinux about this")
+    if_text = _("You want to allow ftpd to write to cifs file systems.")
+    then_text = _("You must tell SELinux about this.")
     do_text = '# setsebool -P allow_ftpd_use_cifs=1 allow_ftpd_anon_write=1'
 
     def __init__(self):

--- a/plugins/src/allow_ftpd_use_nfs.py
+++ b/plugins/src/allow_ftpd_use_nfs.py
@@ -29,42 +29,42 @@ class plugin(Plugin):
     summary = _('''
     SELinux prevented the ftp daemon from $ACCESS files stored on a NFS filesystem.
     ''')
-    
+
     problem_description = _('''
     SELinux prevented the ftp daemon from $ACCESS files stored on a NFS filesystem.
     NFS (Network Filesystem) is a network filesystem commonly used on Unix / Linux
     systems.
-    
+
     The ftp daemon attempted to read one or more files or directories from
     a mounted filesystem of this type.  As NFS filesystems do not support
     fine-grained SELinux labeling, all files and directories in the
     filesystem will have the same security context.
-    
+
     If you have not configured the ftp daemon to read files from a NFS filesystem
     this access attempt could signal an intrusion attempt.
     ''')
-    
+
     fix_description = _('''
     Changing the "allow_ftpd_use_nfs" boolean to true will allow this access:
     "setsebool -P allow_ftpd_use_nfs=1."
     ''')
-    
+
     fix_cmd = 'setsebool -P allow_ftpd_use_nfs=1'
-    
-    rw_fix_description = _(''' Changing the "allow_ftpd_use_nfs" and
+
+    rw_fix_description = _('''Changing the "allow_ftpd_use_nfs" and
     "$WRITE_BOOLEAN" booleans to true will allow this access:
     "setsebool -P allow_ftpd_use_nfs=1 $WRITE_BOOLEAN=1".
     warning: setting the "$WRITE_BOOLEAN" boolean to true will
     allow the ftp daemon to write to all public content (files and
     directories with type public_content_t) in addition to writing to
     files and directories on NFS filesystems.  ''')
-    
+
     rw_fix_cmd = 'setsebool -P allow_ftpd_use_nfs=1 $WRITE_BOOLEAN=1'
-     
-    if_text = _("you want to allow ftpd to write to nfs file systems")
-    then_text = _("you must tell SELinux about this")
+
+    if_text = _("You want to allow ftpd to write to nfs file systems.")
+    then_text = _("You must tell SELinux about this.")
     do_text = 'setsebool -P allow_ftpd_use_nfs=1 allow_ftpd_anon_write=1'
-            
+
     def __init__(self):
         Plugin.__init__(self, __name__)
 

--- a/plugins/src/associate.py
+++ b/plugins/src/associate.py
@@ -24,7 +24,7 @@ _=translation.gettext
 
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
-import os 
+import os
 from stat import *
 
 import selinux
@@ -35,20 +35,20 @@ class plugin(Plugin):
 
     def get_problem_description(self, avc, args):
         return _('''
-You tried to place a type on a %s that is not a file type.  This is not allowed, you must assigne a file type.  You can list all file types using the seinfo command.
+You tried to place a type on a %s that is not a file type. This is not allowed, you must assigne a file type. You can list all file types using the seinfo command.
 
 seinfo -afile_type -x
 
     ''') % args[1]
 
-    if_text = _('you want to change the label of $TARGET_PATH to %s, you are not allowed to since it is not a valid file type.') 
+    if_text = _('You want to change the label of $TARGET_PATH to %s, you are not allowed to since it is not a valid file type.')
 
     def get_if_text(self, avc, args):
         return self.if_text % args[1]
 
-    then_text = _('you must pick a valid file label.')
-    do_text = 'select a valid file type.  List valid file labels by executing: \n# seinfo -afile_type -x'
-    
+    then_text = _('You must pick a valid file label.')
+    do_text = 'Select a valid file type.  List valid file labels by executing: \n# seinfo -afile_type -x'
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(100)

--- a/plugins/src/automount_exec_config.py
+++ b/plugins/src/automount_exec_config.py
@@ -42,7 +42,7 @@ class plugin(Plugin):
 
     fix_cmd = 'chcon -t bin_t $TARGET_PATH'
 
-    then_text = "You need to change the label on '$FIX_TARGET_PATH'"
+    then_text = "You need to change the label on '$FIX_TARGET_PATH'."
 
     do_text = "chcon -t bin_t '$FIX_TARGET_PATH'"
 

--- a/plugins/src/bind_ports.py
+++ b/plugins/src/bind_ports.py
@@ -30,7 +30,7 @@ class plugin(Plugin):
 
     problem_description = _('''
     SELinux has denied the $SOURCE from binding to a network port $PORT_NUMBER which does not have an SELinux type associated with it.
-    If $SOURCE should be allowed to listen on $PORT_NUMBER, use the <i>semanage</i> command to assign $PORT_NUMBER to a port type that $SOURCE_TYPE can bind to (%s). 
+    If $SOURCE should be allowed to listen on $PORT_NUMBER, use the <i>semanage</i> command to assign $PORT_NUMBER to a port type that $SOURCE_TYPE can bind to (%s).
     \n\nIf $SOURCE is not supposed
     to bind to $PORT_NUMBER, this could signal an intrusion attempt.
     ''')
@@ -44,9 +44,9 @@ class plugin(Plugin):
     ''')
 
     fix_cmd = ''
-    if_text = 'you want to allow $SOURCE_PATH to bind to network port $PORT_NUMBER'
-    then_text = 'you need to modify the port type.'
-    
+    if_text = 'You want to allow $SOURCE_PATH to bind to network port $PORT_NUMBER.'
+    then_text = 'You need to modify the port type.'
+
     def get_do_text(self, avc, options):
         ports = options[1].split(",")
         if len(ports) > 1:
@@ -54,7 +54,7 @@ class plugin(Plugin):
     where PORT_TYPE is one of the following: %s.""") % options
         else:
             return _("# semanage port -a -t %s -p %s $PORT_NUMBER") % (options[1], options[0])
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(100)

--- a/plugins/src/catchall.py
+++ b/plugins/src/catchall.py
@@ -47,10 +47,10 @@ class plugin(Plugin):
 
     def get_if_text(self, avc, args):
         if args[1] == "process":
-            return _('you believe that $SOURCE_BASE_PATH should be allowed $ACCESS access on processes labeled $TARGET_TYPE by default.')
+            return _('You believe that $SOURCE_BASE_PATH should be allowed $ACCESS access on processes labeled $TARGET_TYPE by default.')
         if args[1] == "capability":
-            return _('you believe that $SOURCE_BASE_PATH should have the $ACCESS capability by default.')
-        return _('you believe that $SOURCE_BASE_PATH should be allowed $ACCESS access on the $TARGET_BASE_PATH $TARGET_CLASS by default.')
+            return _('You believe that $SOURCE_BASE_PATH should have the $ACCESS capability by default.')
+        return _('You believe that $SOURCE_BASE_PATH should be allowed $ACCESS access on the $TARGET_BASE_PATH $TARGET_CLASS by default.')
 
     then_text = _('You should report this as a bug.\nYou can generate a local policy module to allow this access.')
     do_text = _("""Allow this access for now by executing:

--- a/plugins/src/catchall_boolean.py
+++ b/plugins/src/catchall_boolean.py
@@ -35,15 +35,15 @@ class plugin(Plugin):
 
     problem_description = _('''
 
-    SELinux denied access requested by $SOURCE. The current boolean 
+    SELinux denied access requested by $SOURCE. The current boolean
     settings do not allow this access.  If you have not setup $SOURCE to
-    require this access this may signal an intrusion attempt. If you do intend 
-    this access you need to change the booleans on this system to allow 
+    require this access this may signal an intrusion attempt. If you do intend
+    this access you need to change the booleans on this system to allow
     the access.
     ''')
 
     fix_description = _('''
-    Confined processes can be configured to run requiring different access, SELinux provides booleans to allow you to turn on/off 
+    Confined processes can be configured to run requiring different access, SELinux provides booleans to allow you to turn on/off
     access as needed.
 
     ''')
@@ -59,8 +59,8 @@ class plugin(Plugin):
         txt=seobject.boolean_desc(args[0])
         if not isinstance(txt, unicode):
             txt=unicode(txt, encoding="utf8")
-        return _("you want to %s") % (txt[0].lower() + txt[1:])
-        
+        return _("You want to %s") % (txt[0].lower() + txt[1:])
+
     def get_do_text(self, avc, args):
         return _("setsebool -P %s %s") % (args[0], args[1])
 
@@ -73,10 +73,10 @@ class plugin(Plugin):
             pass
 
         return text
-        
+
     def analyze(self, avc):
         man_page = self.check_for_man(avc.scontext.type)
-        if  len(avc.bools) > 0:            
+        if  len(avc.bools) > 0:
             reports = []
             fix = self.fix_description
             fix_cmd = ""

--- a/plugins/src/catchall_labels.py
+++ b/plugins/src/catchall_labels.py
@@ -27,19 +27,19 @@ class plugin(Plugin):
 
     problem_description = _('''
     SELinux has denied the $SOURCE access to potentially
-    mislabeled files $TARGET_PATH.  This means that SELinux will not
+    mislabeled files $TARGET_PATH. This means that SELinux will not
     allow httpd to use these files. If httpd should be allowed this access to these files you should change the file context to one of the following types, %s.
     Many third party apps install html files
-    in directories that SELinux policy cannot predict.  These directories
+    in directories that SELinux policy cannot predict. These directories
     have to be labeled with a file context which httpd can access.
     ''')
 
-    then_text = _("You need to change the label on $FIX_TARGET_PATH")
+    then_text = _("You need to change the label on $FIX_TARGET_PATH.")
 
     def get_do_text(self, avc, args):
         return _("""# semanage fcontext -a -t FILE_TYPE '$FIX_TARGET_PATH'
-where FILE_TYPE is one of the following: %s. 
-Then execute: 
+where FILE_TYPE is one of the following: %s.
+Then execute:
 restorecon -v '$FIX_TARGET_PATH'
 """) % ", ".join(args)
 

--- a/plugins/src/chrome.py
+++ b/plugins/src/chrome.py
@@ -35,16 +35,16 @@ class plugin(Plugin):
     fix_description = _('''
 Either remove the mozplugger or spice-xpi package by executing 'yum remove mozplugger spice-xpi', or turn off enforcement of SELinux over the Chrome plugins. setsebool -P unconfined_chrome_sandbox_transition 0
     ''')
-    if_text = _("you want to use the %s package")
+    if_text = _("You want to use the %s package.")
 
     def get_if_text(self, avc, args):
         return self.if_text % args[0]
 
-    then_text = _("you must turn off SELinux controls on the Chrome plugins.")
+    then_text = _("You must turn off SELinux controls on the Chrome plugins.")
     do_text = """# setsebool -P unconfined_chrome_sandbox_transition 0"""
 
     fix_cmd = "setsebool -P unconfined_chrome_sandbox_transition 0"
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(50)

--- a/plugins/src/connect_ports.py
+++ b/plugins/src/connect_ports.py
@@ -30,11 +30,10 @@ class plugin(Plugin):
 
     problem_description = _('''
     SELinux has denied $SOURCE from connecting to a network port $PORT_NUMBER which does not have an SELinux type associated with it.
-    If $SOURCE should be allowed to connect on $PORT_NUMBER, use the <i>semanage</i> command to assign $PORT_NUMBER to a port type that $SOURCE_TYPE can connect to (%s). 
+    If $SOURCE should be allowed to connect on $PORT_NUMBER, use the <i>semanage</i> command to assign $PORT_NUMBER to a port type that $SOURCE_TYPE can connect to (%s).
     \n\nIf $SOURCE is not supposed
     to connect to $PORT_NUMBER, this could signal a intrusion attempt.
     ''')
-    
 
     fix_description = _('''
     If you want to allow $SOURCE to connect to $PORT_NUMBER, you can execute \n
@@ -43,9 +42,9 @@ class plugin(Plugin):
     ''')
 
     fix_cmd = ''
-    if_text = 'you want to allow $SOURCE_PATH to connect to network port $PORT_NUMBER'
-    then_text = 'you need to modify the port type.'
-    
+    if_text = 'You want to allow $SOURCE_PATH to connect to network port $PORT_NUMBER.'
+    then_text = 'You need to modify the port type.'
+
     def get_do_text(self, avc, options):
         ports = options[1].split(",")
         if len(ports) > 1:

--- a/plugins/src/cvs_data.py
+++ b/plugins/src/cvs_data.py
@@ -38,11 +38,11 @@ class plugin(Plugin):
     fix_description = _('''
     You can alter the file context by executing chcon -R -t cvs_data_t '$TARGET_PATH'
     You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t cvs_data_t '$FIX_TARGET_PATH'"
-    
+
     ''')
 
-    if_text = _("$TARGET_BASE_PATH should be shared via the cvs daemon")
-    then_text = _("You need to change the label on $TARGET_BASE_PATH'")
+    if_text = _("$TARGET_BASE_PATH should be shared via the cvs daemon.")
+    then_text = _("You need to change the label on $TARGET_BASE_PATH'.")
     do_text = """# semanage fcontext -a -t cvs_data_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""
 

--- a/plugins/src/dac_override.py
+++ b/plugins/src/dac_override.py
@@ -26,23 +26,23 @@ from setroubleshoot.Plugin import Plugin
 
 class plugin(Plugin):
     summary =_('''
-    SELinux is preventing $SOURCE_PATH the "$ACCESS" capability. 
+    SELinux is preventing $SOURCE_PATH the "$ACCESS" capability.
     ''')
 
     problem_description = _('''
-	dac_override and dac_read_search capabilities usually indicates that the root process does not have access to a file based on the permission flags.  This usually mean you have some file with the wrong ownership/permissions on it.
+	dac_override and dac_read_search capabilities usually indicates that the root process does not have access to a file based on the permission flags. This usually mean you have some file with the wrong ownership/permissions on it.
     ''')
 
-    fix_description = "" 
+    fix_description = ""
     fix_cmd = ""
-    if_text = _("you want to help identify if domain needs this access or you have a file with the wrong permissions on your system")
-    then_text = _("turn on full auditing to get path information about the offending file and generate the error again.")
+    if_text = _("You want to help identify if domain needs this access or you have a file with the wrong permissions on your system.")
+    then_text = _("Turn on full auditing to get path information about the offending file and generate the error again.")
     do_text = _("""
 Turn on full auditing
 # auditctl -w /etc/shadow -p w
 Try to recreate AVC. Then execute
 # ausearch -m avc -ts recent
-If you see PATH record check ownership/permissions on file, and fix it, 
+If you see PATH record check ownership/permissions on file, and fix it,
 otherwise report as a bugzilla.""")
 
     def __init__(self):

--- a/plugins/src/device.py
+++ b/plugins/src/device.py
@@ -27,7 +27,7 @@ from setroubleshoot.Plugin import Plugin
 
 class plugin(Plugin):
     summary = _('''
-    SELinux is preventing $SOURCE_PATH "$ACCESS" access to device $TARGET_PATH. 
+    SELinux is preventing $SOURCE_PATH "$ACCESS" access to device $TARGET_PATH.
     ''')
 
     problem_description = _('''
@@ -42,7 +42,7 @@ class plugin(Plugin):
 
     If this device remains labeled device_t, then this is a bug in SELinux policy.
 
-    Please file a bg report.
+    Please file a bug report.
 
     If you look at the other similar devices labels, ls -lZ /dev/SIMILAR, and find a type that would work for $TARGET_PATH,
     you can use chcon -t SIMILAR_TYPE '$TARGET_PATH', If this fixes the problem, you can make this permanent by executing
@@ -50,7 +50,7 @@ class plugin(Plugin):
 
     If the restorecon changes the context, this indicates that the application that created the device, created it without
     using SELinux APIs.  If you can figure out which application created the device, please file a bug report against this application.
-    
+
     ''')
 
     fix_description = _('''
@@ -62,7 +62,7 @@ class plugin(Plugin):
 # restorecon -v '$FIX_TARGET_PATH'""")
 
     fix_cmd = ''
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
 

--- a/plugins/src/disable_ipv6.py
+++ b/plugins/src/disable_ipv6.py
@@ -37,9 +37,9 @@ Disable IPV6 properly.
 
     fix_cmd = ""
 
-    if_text = _("you want to disable IPV6 on this machine")
-    then_text = _("you need to set /proc/sys/net/ipv6/conf/all/disable_ipv6 to 1 and do not blacklist the module'")
-    do_text = _("""Add 
+    if_text = _("You want to disable IPV6 on this machine.")
+    then_text = _("You need to set /proc/sys/net/ipv6/conf/all/disable_ipv6 to 1 and do not blacklist the module'.")
+    do_text = _("""Add
 net.ipv6.conf.all.disable_ipv6 = 1
 to /etc/sysctl.conf
 """)

--- a/plugins/src/file.py
+++ b/plugins/src/file.py
@@ -35,7 +35,7 @@ class plugin(Plugin):
     problem. No files on an SELinux box should ever be labeled file_t.
     If you have just added a disk drive to the system you can
     relabel it using the restorecon command.  For example if you saved the
-home directory from a previous installation that did not use SELinux, 'restorecon -R -v /home' will fix the labels.  Otherwise you should
+home directory from a previous installation that did not use SELinux, 'restorecon -R -v /home' will fix the labels. Otherwise you should
     relabel the entire file system.
     ''')
 
@@ -46,15 +46,15 @@ home directory from a previous installation that did not use SELinux, 'restoreco
 
     def get_if_text(self, avc, args):
         if args == (1,0):
-            return _('this is caused by a newly created file system.')
+            return _('This is caused by a newly created file system.')
         else:
-            return _('you think this is caused by a badly mislabeled machine.')
+            return _('You think this is caused by a badly mislabeled machine.')
 
     def get_then_text(self, avc, args):
         if args == (1,0):
-            return _('you need to add labels to it.')
+            return _('You need to add labels to it.')
         else:
-            return _('you need to fully relabel.')
+            return _('You need to fully relabel.')
 
     def get_do_text(self, avc, args):
         if args == (1,0):

--- a/plugins/src/filesystem_associate.py
+++ b/plugins/src/filesystem_associate.py
@@ -34,16 +34,16 @@ class plugin(Plugin):
     copying between file systems, "cp -a" for example.  Not all file contexts should be maintained
     between the file systems.  For example, a read-only file type like iso9660_t should not be placed
     on a r/w system.  "cp -p" might be a better solution, as this will adopt the default file context
-    for the destination.  
+    for the destination.
     ''')
 
     fix_description = _('''
     Use a command like "cp -p" to preserve all permissions except SELinux context.
     ''')
-    if_text = _("you believe $SOURCE_BASE_PATH should be allowed to create $TARGET_BASE_PATH files")
-    then_text = _("you need to use a different command. You are not allowed to preserve the SELinux context on the target file system.")
+    if_text = _("You believe $SOURCE_BASE_PATH should be allowed to create $TARGET_BASE_PATH files.")
+    then_text = _("You need to use a different command. You are not allowed to preserve the SELinux context on the target file system.")
 
-    do_text = _('use a command like "cp -p" to preserve all permissions except SELinux context.')
+    do_text = _('Use a command like "cp -p" to preserve all permissions except SELinux context.')
 
     def __init__(self):
         Plugin.__init__(self, __name__)

--- a/plugins/src/httpd_can_sendmail.py
+++ b/plugins/src/httpd_can_sendmail.py
@@ -31,8 +31,8 @@ class plugin(Plugin):
 
     problem_description = _('''
     SELinux has denied the http daemon from sending mail. An
-    httpd script is trying to connect to a mail port or execute the 
-    sendmail command. If you did not setup httpd to sendmail, this could 
+    httpd script is trying to connect to a mail port or execute the
+    sendmail command. If you did not setup httpd to sendmail, this could
     signal a intrusion attempt.
     ''')
 
@@ -44,10 +44,10 @@ class plugin(Plugin):
 
     fix_cmd = 'setsebool -P $BOOLEAN=1'
 
-    if_text = _("you want to allow httpd to send mail")
-    then_text = _("you must setup SELinux to allow this")
+    if_text = _("You want to allow httpd to send mail.")
+    then_text = _("You must setup SELinux to allow this.")
     do_text = 'setsebool -P httpd_can_sendmail=1'
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.level="green"

--- a/plugins/src/httpd_unified.py
+++ b/plugins/src/httpd_unified.py
@@ -29,7 +29,7 @@ class plugin(Plugin):
     summary = _('''
     SELinux prevented httpd $ACCESS access to http files.
     ''')
-    
+
     problem_description = _('''
     SELinux prevented httpd $ACCESS access to http files.
 
@@ -41,21 +41,21 @@ class plugin(Plugin):
     httpd_TYPE_content_t, it is writable content. it needs to be labeled
     httpd_TYPE_script_rw_t or httpd_TYPE_script_ra_t. You can use the
     chcon command to change these context.  Please refer to the man page
-    "man httpd_selinux" or 
+    "man httpd_selinux" or
     <a href="http://fedora.redhat.com/docs/selinux-apache-fc3">FAQ</a>
     "TYPE" refers to one of "sys", "user" or "staff" or potentially other
     script types.
     ''')
-    
+
     fix_description = _('''
     Changing the "$BOOLEAN" boolean to true will allow this access:
     "setsebool -P $BOOLEAN=1"
     ''')
-    
+
     fix_cmd = 'setsebool -P $BOOLEAN=1'
 
-    if_text = _("you want to allow httpd to execute cgi scripts and to unify HTTPD handling of all content files.")
-    then_text = _("you must tell SELinux about this by enabling the 'httpd_unified' and 'http_enable_cgi' booleans")
+    if_text = _("You want to allow httpd to execute cgi scripts and to unify HTTPD handling of all content files.")
+    then_text = _("You must tell SELinux about this by enabling the 'httpd_unified' and 'http_enable_cgi' booleans.")
     do_text = "# setsebool -P httpd_unified=1 httpd_enable_cgi=1"
 
     def __init__(self):

--- a/plugins/src/httpd_write_content.py
+++ b/plugins/src/httpd_write_content.py
@@ -30,21 +30,21 @@ class plugin(Plugin):
     problem_description = _('''
     SELinux prevented httpd $ACCESS access to $TARGET_PATH.
 
-    httpd scripts are not allowed to write to content without explicit 
-    labeling of all files.  If $TARGET_PATH is writable content. it needs 
-    to be labeled httpd_sys_rw_content_t or if all you need is append you can label it httpd_sys_ra_content_t.   Please refer to 'man httpd_selinux' for more information on setting up httpd and selinux.
+    httpd scripts are not allowed to write to content without explicit
+    labeling of all files.  If $TARGET_PATH is writable content. it needs
+    to be labeled httpd_sys_rw_content_t or if all you need is append you can label it httpd_sys_ra_content_t. Please refer to 'man httpd_selinux' for more information on setting up httpd and selinux.
     ''')
-    
+
     fix_cmd = "chcon -R -t httpd_sys_rw_content_t '$TARGET_PATH'"
-    
-    then_text = _("You need to change the label on '$FIX_TARGET_PATH'")
+
+    then_text = _("You need to change the label on '$FIX_TARGET_PATH'.")
     do_text = """# semanage fcontext -a -t httpd_sys_rw_content_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""
 
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(100)
-        
+
     def analyze(self, avc):
         if avc.matches_source_types(['httpd_t', 'httpd_sys_script_t'])  and \
            avc.matches_target_types(['httpd_sys_content_t'])                     and \

--- a/plugins/src/kernel_modules.py
+++ b/plugins/src/kernel_modules.py
@@ -31,18 +31,18 @@ class plugin(Plugin):
     ''')
 
     problem_description = _('''
-    SELinux has prevented $SOURCE from modifying $TARGET.  This denial 
-    indicates $SOURCE was trying to modify the way the kernel runs or to 
-    actually insert code into the kernel. All applications that need this 
-    access should have already had policy written for them.  If a compromised 
-    application tries to modify the kernel this AVC will be generated. This is a 
+    SELinux has prevented $SOURCE from modifying $TARGET.  This denial
+    indicates $SOURCE was trying to modify the way the kernel runs or to
+    actually insert code into the kernel. All applications that need this
+    access should have already had policy written for them.  If a compromised
+    application tries to modify the kernel this AVC will be generated. This is a
     serious issue. Your system may very well be compromised.
     ''')
 
-    fix_description = "Contact your security administrator and report this issue." 
+    fix_description = "Contact your security administrator and report this issue."
     fix_cmd = ""
-    if_text = _("you do not think $SOURCE_BASE_PATH should try $ACCESS access on $TARGET_BASE_PATH.")
-    then_text = _("you may be under attack by a hacker, since confined applications should not need this access.")
+    if_text = _("You do not think $SOURCE_BASE_PATH should try $ACCESS access on $TARGET_BASE_PATH.")
+    then_text = _("You may be under attack by a hacker, since confined applications should not need this access.")
     do_text = _("Contact your security administrator and report this issue.")
 
     def __init__(self):

--- a/plugins/src/leaks.py
+++ b/plugins/src/leaks.py
@@ -27,11 +27,11 @@ class plugin(Plugin):
     summary =_('''
     SELinux is preventing $SOURCE_PATH access to a leaked $TARGET_PATH file descriptor.
     ''')
-    
+
     problem_description = _('''
     SELinux denied access requested by the $SOURCE command. It looks like this is either a leaked descriptor or $SOURCE output was redirected to a file it is not allowed to access.  Leaks usually can be ignored since SELinux is just closing the leak and reporting the error.  The application does not use the descriptor, so it will run properly.  If this is a redirection, you will not get output in the $TARGET_PATH.  You should generate a bugzilla on selinux-policy, and it will get routed to the appropriate package.  You can safely ignore this avc.
     ''')
-    
+
     fix_description = _('''
     You can generate a local policy module to allow this
     access - see <a href="http://docs.fedoraproject.org/selinux-faq-fc5/#id2961385">FAQ</a>
@@ -39,7 +39,7 @@ class plugin(Plugin):
 
     fix_cmd = ""
 
-    if_text = _('you want to ignore $SOURCE_BASE_PATH trying to $ACCESS access the $TARGET_BASE_PATH $TARGET_CLASS, because you believe it should not need this access.')
+    if_text = _('You want to ignore $SOURCE_BASE_PATH trying to $ACCESS access the $TARGET_BASE_PATH $TARGET_CLASS, because you believe it should not need this access.')
     then_text = _('You should report this as a bug.  \nYou can generate a local policy module to dontaudit this access.')
     do_text = _("""# grep $SOURCE_PATH /var/log/audit/audit.log | audit2allow -D -M mypol
 # semodule -i mypol.pp""")

--- a/plugins/src/mmap_zero.py
+++ b/plugins/src/mmap_zero.py
@@ -31,20 +31,20 @@ class plugin(Plugin):
     ''')
 
     problem_description = _('''
-    SELinux has denied the $SOURCE the ability to mmap low area of the kernel 
-    address space.  The ability to mmap a low area of the address space, as 
-    configured by /proc/sys/kernel/mmap_min_addr.  Preventing such mappings 
-    helps protect against exploiting null deref bugs in the kernel. All 
-    applications that need this access should have already had policy written 
-    for them.  If a compromised application tries modify the kernel this AVC 
-    would be generated. This is a serious issue. Your system may very well be 
+    SELinux has denied the $SOURCE the ability to mmap low area of the kernel
+    address space.  The ability to mmap a low area of the address space, as
+    configured by /proc/sys/kernel/mmap_min_addr.  Preventing such mappings
+    helps protect against exploiting null deref bugs in the kernel. All
+    applications that need this access should have already had policy written
+    for them.  If a compromised application tries modify the kernel this AVC
+    would be generated. This is a serious issue. Your system may very well be
     compromised.
     ''')
 
     fix_description = ("Contact your security administrator and report this issue.")
     fix_cmd = ""
-    if_text = _("you do not think $SOURCE_PATH should need to mmap low memory in the kernel.")
-    then_text = _("you may be under attack by a hacker, this is a very dangerous access.")
+    if_text = _("You do not think $SOURCE_PATH should need to mmap low memory in the kernel.")
+    then_text = _("You may be under attack by a hacker, this is a very dangerous access.")
     do_text = _("Contact your security administrator and report this issue.")
     def __init__(self):
         Plugin.__init__(self, __name__)

--- a/plugins/src/mounton.py
+++ b/plugins/src/mounton.py
@@ -36,7 +36,7 @@ class plugin(Plugin):
     or directory "$TARGET_PATH" of type "$TARGET_TYPE". By default
     SELinux limits the mounting of filesystems to only some files or
     directories (those with types that have the mountpoint attribute). The
-    type "$TARGET_TYPE" does not have this attribute. You can change the 
+    type "$TARGET_TYPE" does not have this attribute. You can change the
     label of the file or directory.
     ''')
 
@@ -45,13 +45,13 @@ class plugin(Plugin):
     "chcon -t mnt_t '$TARGET_PATH'."
     You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t mnt_t '$FIX_TARGET_PATH'"
     ''')
-    if_text = _("you want to allow $SOURCE_BASE_PATH to mount on $TARGET_BASE_PATH.")
-    then_text = _("you must change the labeling on $TARGET_PATH.")
+    if_text = _("You want to allow $SOURCE_BASE_PATH to mount on $TARGET_BASE_PATH.")
+    then_text = _("You must change the labeling on $TARGET_PATH.")
     do_text = """# semanage fcontext -a -t mnt_t '$FIX_TARGET_PATH'
 # restorecon -v $TARGET_PATH"""
 
     fix_cmd = "chcon -t mnt_t '$TARGET_PATH'"
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
 

--- a/plugins/src/mozplugger.py
+++ b/plugins/src/mozplugger.py
@@ -35,16 +35,16 @@ class plugin(Plugin):
     fix_description = _('''
 Either remove the mozplugger or spice-xpi package by executing 'yum remove mozplugger spice-xpi' or turn off enforcement of SELinux over the Firefox plugins. setsebool -P unconfined_mozilla_plugin_transition 0
     ''')
-    if_text = _("you want to use the %s package")
+    if_text = _("You want to use the %s package.")
 
     def get_if_text(self, avc, args):
         return self.if_text % args[0]
 
-    then_text = _("you must turn off SELinux controls on the Firefox plugins.")
+    then_text = _("You must turn off SELinux controls on the Firefox plugins.")
     do_text = """# setsebool -P unconfined_mozilla_plugin_transition 0"""
 
     fix_cmd = "setsebool -P unconfined_mozilla_plugin_transition 0"
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(75)
@@ -52,7 +52,7 @@ Either remove the mozplugger or spice-xpi package by executing 'yum remove mozpl
     def analyze(self, avc):
         if avc.matches_source_types(['mozilla_plugin_t']):
             reports = []
-            if get_rpm_nvr_by_name("mozplugger"):                
+            if get_rpm_nvr_by_name("mozplugger"):
                 reports.append(self.report(("mozplugger", None)))
             if get_rpm_nvr_by_name("spice-xpi"):
                 reports.append(self.report(("spice-xpi", None)))

--- a/plugins/src/mozplugger_remove.py
+++ b/plugins/src/mozplugger_remove.py
@@ -37,16 +37,16 @@ class plugin(Plugin):
     ''')
 
     fix_description = _('''
-Either remove the mozplluger package by executing 'yum remove mozplugger'
+Either remove the mozplugger package by executing 'yum remove mozplugger'
 Or turn off enforcement of SELinux over the Firefox plugins.
 setsebool -P unconfined_mozilla_plugin_transition 0
     ''')
-    if_text = _("you want to to continue using SELinux Firefox plugin containment rather then using mozplugger package")
-    then_text = _("you must remove the mozplugger package.")
+    if_text = _("You want to to continue using SELinux Firefox plugin containment rather then using mozplugger package.")
+    then_text = _("You must remove the mozplugger package.")
     do_text = """# yum remove mozplugger"""
 
     fix_cmd = "yum remove mozplugger"
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(99)

--- a/plugins/src/openvpn.py
+++ b/plugins/src/openvpn.py
@@ -24,7 +24,7 @@ _=translation.gettext
 
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
-import os 
+import os
 from stat import *
 
 class plugin(Plugin):
@@ -34,7 +34,7 @@ class plugin(Plugin):
 
     problem_description = _('''
     SELinux denied access requested by $SOURCE. $TARGET_PATH may
-    be a mislabeled. openvpn is allowed to read content in home directory if it 
+    be a mislabeled. openvpn is allowed to read content in home directory if it
     is labeled correctly.
     ''')
 
@@ -45,15 +45,15 @@ class plugin(Plugin):
 
     def get_if_text(self, avc, args):
         if (args[0] == "move"):
-            return _('you want to mv $TARGET_BASE_PATH to standard location so that $SOURCE_BASE_PATH can have $ACCESS access')
+            return _('You want to mv $TARGET_BASE_PATH to standard location so that $SOURCE_BASE_PATH can have $ACCESS access.')
         else:
-            return _('you want to modify the label on $TARGET_BASE_PATH so that $SOURCE_BASE_PATH can have $ACCESS access on it')
-        
+            return _('You want to modify the label on $TARGET_BASE_PATH so that $SOURCE_BASE_PATH can have $ACCESS access on it.')
+
     def get_then_text(self, avc, args):
         if (args[0] == "move"):
-            return _('you must move the cert file to the ~/.cert directory')
+            return _('You must move the cert file to the ~/.cert directory.')
         else:
-            return _('you must fix the labels.')
+            return _('You must fix the labels.')
 
     def get_do_text(self, avc, args):
         if (args[0] == "move"):
@@ -78,5 +78,3 @@ class plugin(Plugin):
             return [self.report(("move",None)), self.report(("fixlabel",None))]
 
         return None
-
-        

--- a/plugins/src/public_content.py
+++ b/plugins/src/public_content.py
@@ -42,12 +42,12 @@ class plugin(Plugin):
     ''')
 
     fix_cmd = "chcon -t public_content_t '$TARGET_PATH'"
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(8)
 
-    if_text=_("you want to treat $TARGET_BASE_PATH as public content")
+    if_text=_("You want to treat $TARGET_BASE_PATH as public content.")
     then_text = _("You need to change the label on $TARGET_BASE_PATH to public_content_t or public_content_rw_t.")
     do_text = """# semanage fcontext -a -t public_content_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""

--- a/plugins/src/qemu_blk_image.py
+++ b/plugins/src/qemu_blk_image.py
@@ -41,8 +41,8 @@ class plugin(Plugin):
     ''')
 
     fix_cmd = "chcon -t virt_image_t '$TARGET_PATH'"
-    
-    then_text = _("You need to change the label on '$FIX_TARGET_PATH'")
+
+    then_text = _("You need to change the label on '$FIX_TARGET_PATH'.")
     do_text = _("""# semanage fcontext -a -t virt_image_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'""")
 

--- a/plugins/src/qemu_file_image.py
+++ b/plugins/src/qemu_file_image.py
@@ -39,14 +39,14 @@ class plugin(Plugin):
     ''')
 
     fix_description = _('''
-    You can alter the file context by executing chcon -t virt_image_t '$TARGET_PATH'
+    You can alter the file context by executing chcon -t virt_image_t '$TARGET_PATH'.
     You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t virt_image_t '$FIX_TARGET_PATH'"
     ''')
 
     fix_cmd = "chcon -t virt_image_t '$TARGET_PATH'"
-    
-    if_text = _("$TARGET_BASE_PATH is a virtualization target")
-    then_text = _("You need to change the label on $TARGET_BASE_PATH'")
+
+    if_text = _("$TARGET_BASE_PATH is a virtualization target.")
+    then_text = _("You need to change the label on $TARGET_BASE_PATH'.")
     do_text = """# semanage fcontext -a -t virt_image_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""
     def __init__(self):

--- a/plugins/src/restorecon.py
+++ b/plugins/src/restorecon.py
@@ -24,7 +24,7 @@ _=translation.gettext
 
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
-import os 
+import os
 from stat import *
 import selinux
 
@@ -47,7 +47,7 @@ class plugin(Plugin):
 
     fix_description = _('''
     You can restore the default system context to this file by executing the
-    restorecon command.  restorecon '$TARGET_PATH', if this file is a directory,
+    restorecon command. restorecon '$TARGET_PATH', if this file is a directory,
     you can recursively restore using restorecon -R '$TARGET_PATH'.
     ''')
 
@@ -71,21 +71,21 @@ class plugin(Plugin):
     </ul>
     This file could have been mislabeled either by user error, or if an normally confined application
     was run under the wrong domain.
-    <p> 
+    <p>
     However, this might also indicate a bug in SELinux because the file should not have been labeled
     with this type.
     <p>
     If you believe this is a bug, please file a bug report against this package.
     ''') % args[1]
 
-    if_text = _('you want to fix the label. \n$TARGET_PATH default label should be %s.') 
+    if_text = _('You want to fix the label.\n$TARGET_PATH default label should be %s.')
 
     def get_if_text(self, avc, args):
         return self.if_text % args[1]
 
-    then_text = _('you can run restorecon.')
+    then_text = _('You can run restorecon.')
     do_text = '# /sbin/restorecon -v $TARGET_PATH'
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(100)
@@ -98,14 +98,14 @@ class plugin(Plugin):
         if avc.tcontext.type in [ "cifs_t", "nfs_t" ]: return None
         if avc.tcontext.type not in file_types: return None
         if avc.all_accesses_are_in("relabelto"): return None
-        restorecon_files = {} 
+        restorecon_files = {}
         restorecon_files['dir'] = S_IFDIR
         restorecon_files['file'] = S_IFREG
         restorecon_files['lnk_file'] = S_IFLNK
         restorecon_files['chr_file'] = S_IFCHR
         restorecon_files['blk_file'] = S_IFBLK
 
-        if avc.has_tclass_in(restorecon_files.keys()):               
+        if avc.has_tclass_in(restorecon_files.keys()):
             if avc.tpath is None: return None
             if avc.tpath == "/": return None
             if avc.tpath[0] != '/': return None

--- a/plugins/src/restorecon_source.py
+++ b/plugins/src/restorecon_source.py
@@ -24,7 +24,7 @@ _=translation.gettext
 
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
-import os 
+import os
 from stat import *
 import selinux
 
@@ -50,21 +50,21 @@ class plugin(Plugin):
     <p>
     This file could have been mislabeled either by user error, or if an normally confined application
     was run under the wrong domain.
-    <p> 
+    <p>
     However, this might also indicate a bug in SELinux because the file should not have been labeled
     with this type.
     <p>
     If you believe this is a bug, please file a bug report against this package.
     ''') % args[1]
 
-    if_text = _('you want to fix the label. \n$SOURCE_PATH default label should be %s.') 
+    if_text = _('You want to fix the label.\n$SOURCE_PATH default label should be %s.')
 
     def get_if_text(self, avc, args):
         return self.if_text % args[1]
 
-    then_text = _('you can run restorecon.')
+    then_text = _('You can run restorecon.')
     do_text = '# /sbin/restorecon -v $SOURCE_PATH'
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
         self.set_priority(100)

--- a/plugins/src/rsync_data.py
+++ b/plugins/src/rsync_data.py
@@ -36,14 +36,14 @@ class plugin(Plugin):
     ''')
 
     fix_description = _('''
-    You can alter the file context by executing chcon -R -t rsync_data_t '$TARGET_PATH'
-    You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t rsync_data_t '$FIX_TARGET_PATH'"
+    You can alter the file context by executing chcon -R -t rsync_data_t '$TARGET_PATH'.
+    You must also change the default file context files on the system in order to preserve them even on a full relabel. "semanage fcontext -a -t rsync_data_t '$FIX_TARGET_PATH'"
     ''')
 
     fix_cmd = "chcon -R -t rsync_data_t '$TARGET_PATH'"
-    
-    if_text = _("$TARGET_BASE_PATH should be shared via the rsync daemon")
-    then_text = _("You need to change the label on $TARGET_BASE_PATH")
+
+    if_text = _("$TARGET_BASE_PATH should be shared via the rsync daemon.")
+    then_text = _("You need to change the label on $TARGET_BASE_PATH.")
     do_text = """# semanage fcontext -a -t rsync_data_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""
 

--- a/plugins/src/samba_share.py
+++ b/plugins/src/samba_share.py
@@ -37,19 +37,19 @@ class plugin(Plugin):
     ''')
 
     fix_description = _('''
-    You can alter the file context by executing chcon -R -t samba_share_t '$TARGET_PATH'
-    You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t samba_share_t '$FIX_TARGET_PATH'"
+    You can alter the file context by executing chcon -R -t samba_share_t '$TARGET_PATH'.
+    You must also change the default file context files on the system in order to preserve them even on a full relabel. "semanage fcontext -a -t samba_share_t '$FIX_TARGET_PATH'"
     ''')
 
     fix_cmd = "chcon -R -t samba_share_t '$TARGET_PATH'"
-    then_text = _("You need to change the label on '$FIX_TARGET_PATH'")
+    then_text = _("You need to change the label on '$FIX_TARGET_PATH'.")
     def get_do_text(self, avc, tclass):
         dpath = ""
         rflag = ""
         if tclass == "dir":
             dpath = "(/.*)?"
             rflag = "-R"
-            
+
         return _("""# semanage fcontext -a -t samba_share_t '$FIX_TARGET_PATH%s'
 # restorecon %s -v '$FIX_TARGET_PATH'""") % (dpath, rflag)
 

--- a/plugins/src/sandbox_connect.py
+++ b/plugins/src/sandbox_connect.py
@@ -36,7 +36,6 @@ class plugin(Plugin):
     \n\nIf $SOURCE is not supposed
     to connect to $PORT_NUMBER, this could signal a intrusion attempt.
     ''')
-    
 
     fix_description = _('''
     If you want to allow $SOURCE to connect to $PORT_NUMBER, you can execute \n
@@ -44,9 +43,9 @@ class plugin(Plugin):
     ''')
 
     fix_cmd = ''
-    if_text = _('you want to allow $SOURCE_PATH to connect to network port $PORT_NUMBER')
+    if_text = _('You want to allow $SOURCE_PATH to connect to network port $PORT_NUMBER.')
 
-    then_text =  _("""you need to modify the sandbox type. sandbox_web_t or sandbox_net_t. 
+    then_text =  _("""You need to modify the sandbox type. sandbox_web_t or sandbox_net_t.
 For example:
 sandbox -X -t sandbox_net_t $SOURCE_PATH
 Please read 'sandbox' man page for more details.

--- a/plugins/src/selinuxpolicy.py
+++ b/plugins/src/selinuxpolicy.py
@@ -31,18 +31,18 @@ class plugin(Plugin):
     ''')
 
     problem_description = _('''
-    SELinux has prevented $SOURCE from modifying $TARGET.  This denial 
-    indicates $SOURCE was trying to modify the selinux policy configuration. 
-    All applications that need this access should have already had policy 
+    SELinux has prevented $SOURCE from modifying $TARGET.  This denial
+    indicates $SOURCE was trying to modify the selinux policy configuration.
+    All applications that need this access should have already had policy
     written for them.  If a compromised application tries to modify the SELinux
-    policy this AVC will be generated. This is a serious issue. Your system 
+    policy this AVC will be generated. This is a serious issue. Your system
     may very well be compromised.
     ''')
 
-    fix_description = "Contact your security administrator and report this issue." 
+    fix_description = "Contact your security administrator and report this issue."
     fix_cmd = ""
-    if_text = _("you do not think $SOURCE_BASE_PATH should try $ACCESS access on $TARGET_BASE_PATH.")
-    then_text = _("you may be under attack by a hacker, since confined applications should not need this access.")
+    if_text = _("You do not think $SOURCE_BASE_PATH should try $ACCESS access on $TARGET_BASE_PATH.")
+    then_text = _("You may be under attack by a hacker, since confined applications should not need this access.")
     do_text = _("Contact your security administrator and report this issue.")
 
     def __init__(self):

--- a/plugins/src/setenforce.py
+++ b/plugins/src/setenforce.py
@@ -42,11 +42,11 @@ class plugin(Plugin):
     well be compromised.
     ''')
 
-    fix_description = "Contact your security administrator and report this issue." 
+    fix_description = "Contact your security administrator and report this issue."
     fix_cmd = ""
 
-    if_text = _("you believe $SOURCE_PATH tried to disable SELinux.")
-    then_text = _("you may be under attack by a hacker, since confined applications should never need this access.")
+    if_text = _("You believe $SOURCE_PATH tried to disable SELinux.")
+    then_text = _("You may be under attack by a hacker, since confined applications should never need this access.")
     do_text = _("Contact your security administrator and report this issue.")
 
     def __init__(self):

--- a/plugins/src/sshd_root.py
+++ b/plugins/src/sshd_root.py
@@ -24,7 +24,7 @@ _=translation.gettext
 
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
-import os 
+import os
 from stat import *
 
 import selinux
@@ -35,16 +35,16 @@ class plugin(Plugin):
 
     problem_description = _('''
     SELinux denied access requested by $SOURCE. $TARGET_PATH may
-    be a mislabeled. sshd is allowed to read content in /root/.ssh directory if it 
+    be a mislabeled. sshd is allowed to read content in /root/.ssh directory if it
     is labeled correctly.
     ''')
 
     fix_description = _('''
     You can restore the default system context to this file by executing the
-    restorecon command.  restorecon restore using restorecon -R /root/.ssh.
+    restorecon command. restorecon restore using restorecon -R /root/.ssh.
     ''')
 
-    then_text = _('you must fix the labels.')
+    then_text = _('You must fix the labels.')
     do_text = "/sbin/restorecon -Rv /root/.ssh"
 
     def __init__(self):
@@ -62,4 +62,3 @@ class plugin(Plugin):
             return self.report()
 
         return None
-        

--- a/plugins/src/swapfile.py
+++ b/plugins/src/swapfile.py
@@ -37,13 +37,13 @@ class plugin(Plugin):
     ''')
 
     fix_description = _('''
-    You can alter the file context by executing chcon -t swapfile_t '$TARGET_PATH'
+    You can alter the file context by executing chcon -t swapfile_t '$TARGET_PATH'.
     You must also change the default file context files on the system in order to preserve them even on a full relabel.  "semanage fcontext -a -t swapfile_t '$FIX_TARGET_PATH'"
     ''')
 
     fix_cmd = "chcon -t swapfile_t '$TARGET_PATH'"
 
-    then_text = _("You need to change the label on '$FIX_TARGET_PATH'")
+    then_text = _("You need to change the label on '$FIX_TARGET_PATH'.")
     do_text = """# semanage fcontext -a -t swapfile_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""
     def __init__(self):

--- a/plugins/src/sys_module.py
+++ b/plugins/src/sys_module.py
@@ -37,14 +37,14 @@ class plugin(Plugin):
     problem_description = _('''
     SELinux has prevented $SOURCE from loading a kernel module.
     All confined programs that need to load kernel modules should have already had policy
-    written for them. If a compromised application 
-    tries to modify the kernel this AVC will be generated. This is a serious 
+    written for them. If a compromised application
+    tries to modify the kernel this AVC will be generated. This is a serious
     issue. Your system may very well be compromised.
     ''')
 
-    fix_description = "Contact your security administrator and report this issue." 
-    if_text = _("you do not believe that $SOURCE_PATH should be attempting to modify the kernel by loading a kernel module.") 
-    then_text = _("A process might be attempting to hack into your system.") 
+    fix_description = "Contact your security administrator and report this issue."
+    if_text = _("You do not believe that $SOURCE_PATH should be attempting to modify the kernel by loading a kernel module.")
+    then_text = _("A process might be attempting to hack into your system.")
     do_text = _("Contact your security administrator and report this issue.")
     fix_cmd = ""
     def __init__(self):

--- a/plugins/src/sys_resource.py
+++ b/plugins/src/sys_resource.py
@@ -26,18 +26,18 @@ from setroubleshoot.Plugin import Plugin
 
 class plugin(Plugin):
     summary =_('''
-    SELinux is preventing $SOURCE_PATH the "sys_resource" capability. 
+    SELinux is preventing $SOURCE_PATH the "sys_resource" capability.
     ''')
 
     problem_description = _('''
-    Confined domains should not require "sys_resource". This usually means that     your system is running out some system resource like disk space, memory, quota etc. Please clear up the disk and this
-    AVC message should go away. If this AVC continues after you clear up the disk space, please report this as a bug. 
+    Confined domains should not require "sys_resource". This usually means that your system is running out some system resource like disk space, memory, quota etc. Please clear up the disk and this
+    AVC message should go away. If this AVC continues after you clear up the disk space, please report this as a bug.
     ''')
 
-    fix_description = "Fix the cause of the SYS_RESOURCE on your system." 
+    fix_description = "Fix the cause of the SYS_RESOURCE on your system."
 
-    if_text = _("you do not want processes to require capabilities to use up all the system resources on your system;") 
-    then_text = _("""you need to diagnose why your system is running out of system resources and fix the problem.  
+    if_text = _("You do not want processes to require capabilities to use up all the system resources on your system;")
+    then_text = _("""You need to diagnose why your system is running out of system resources and fix the problem.
 
 According to /usr/include/linux/capability.h, sys_resource is required to:
 
@@ -75,7 +75,7 @@ According to /usr/include/linux/capability.h, sys_resource is required to:
 /* Override max number of consoles on console allocation */
 /* Override max number of keymaps */
 """)
-    do_text = "Fix the cause of the SYS_RESOURCE on your system." 
+    do_text = "Fix the cause of the SYS_RESOURCE on your system."
 
     def __init__(self):
         Plugin.__init__(self, __name__)

--- a/plugins/src/vbetool.py
+++ b/plugins/src/vbetool.py
@@ -35,8 +35,8 @@ class plugin(Plugin):
 SELinux denied an operation requested by $SOURCE, a program used
 to alter video hardware state.  This program is known to use
 an unsafe operation on system memory but so are a number of
-malware/exploit programs which masquerade as vbetool.  This tool is used to 
-reset video state when a machine resumes from a suspend.  If your machine 
+malware/exploit programs which masquerade as vbetool.  This tool is used to
+reset video state when a machine resumes from a suspend.  If your machine
 is not resuming properly your only choice is to allow this
 operation and reduce your system security against such malware.
 
@@ -52,8 +52,8 @@ executing:
 
     fix_cmd = "/usr/sbin/setsebool -P mmap_low_allowed 1"
 
-    if_text=_("you want to ignore this AVC because it is dangerous and your machine seems to be working correctly.")
-    then_text = _("you must tell SELinux about this by enabling the vbetool_mmap_zero_ignore boolean.")
+    if_text=_("You want to ignore this AVC because it is dangerous and your machine seems to be working correctly.")
+    then_text = _("You must tell SELinux about this by enabling the vbetool_mmap_zero_ignore boolean.")
     do_text = "# setsebool -P vbetool_mmap_zero_ignore 1"
 
     def __init__(self):
@@ -64,7 +64,7 @@ executing:
     def analyze(self, avc):
         if avc.has_any_access_in(['mmap_zero']) and \
                 avc.matches_source_types(['vbetool_t']) and \
-                os.stat(avc.spath).st_uid == 0:            
+                os.stat(avc.spath).st_uid == 0:
 
             # MATCH
             return self.report()

--- a/plugins/src/wine.py
+++ b/plugins/src/wine.py
@@ -44,7 +44,7 @@ attempting to run a Windows application this indicates you are likely
 being attacked by some for of malware or program trying to exploit your
 system for nefarious purposes.
 
-Please refer to 
+Please refer to
 
 http://wiki.winehq.org/PreloaderPageZeroProblem
 
@@ -63,8 +63,8 @@ executing:
 
     fix_cmd = "/usr/sbin/setsebool -P mmap_low_allowed 1"
 
-    if_text=_("you want to ignore this AVC because it is dangerous and your wine applications are working correctly.")
-    then_text = _("you must tell SELinux about this by enabling the wine_mmap_zero_ignore boolean.")
+    if_text=_("You want to ignore this AVC because it is dangerous and your wine applications are working correctly.")
+    then_text = _("You must tell SELinux about this by enabling the wine_mmap_zero_ignore boolean.")
     do_text = "# setsebool -P wine_mmap_zero_ignore 1"
 
     def __init__(self):
@@ -75,7 +75,7 @@ executing:
     def analyze(self, avc):
         if avc.has_any_access_in(['mmap_zero']) and \
                 avc.matches_source_types(['.*wine_t']) and \
-                os.stat(avc.spath).st_uid == 0:            
+                os.stat(avc.spath).st_uid == 0:
 
             # MATCH
             return self.report()

--- a/plugins/src/xen_image.py
+++ b/plugins/src/xen_image.py
@@ -33,7 +33,7 @@ class plugin(Plugin):
     If this is a XEN image, it has to have a file context label of
     xen_image_t. The system is setup to label image files in directory /var/lib/xen/images
     correctly.  We recommend that you copy your image file to /var/lib/xen/images.
-    If you really want to have your xen image files in the current directory, you can relabel $TARGET_PATH to be xen_image_t using chcon.  You also need to execute semanage fcontext -a -t xen_image_t '$FIX_TARGET_PATH' to add this
+    If you really want to have your xen image files in the current directory, you can relabel $TARGET_PATH to be xen_image_t using chcon. You also need to execute semanage fcontext -a -t xen_image_t '$FIX_TARGET_PATH' to add this
     new path to the system defaults. If you did not intend to use $TARGET_PATH as a xen
     image it could indicate either a bug or an intrusion attempt.
     ''')
@@ -49,7 +49,7 @@ class plugin(Plugin):
 
     do_text = """# semanage fcontext -a -t xen_image_t '$FIX_TARGET_PATH'
 # restorecon -v '$FIX_TARGET_PATH'"""
-    
+
     def __init__(self):
         Plugin.__init__(self, __name__)
 

--- a/plugins/tools/plugins.py
+++ b/plugins/tools/plugins.py
@@ -14,7 +14,7 @@ def setroubleshoot_print( se_plugin ):
         rec += "</fix>\n"
         rec += "</setroubleshoot>"
         return rec
-    
+
 __all__ = ['RunFaultServer',
            'get_host_database',
            'send_alert_notification',
@@ -27,7 +27,7 @@ gettext.install(domain    = get_config('general', 'i18n_text_domain'),
                 codeset   = get_config('general', 'i18n_encoding'))
 
 from setroubleshoot.util import *
-se_plugins = {} 
+se_plugins = {}
 plugins = load_plugins()
 for p in plugins:
     se_plugins[p.analysis_id.split(".")[1]] = p


### PR DESCRIPTION
If/Then sentences should now uniformly begin with a capital letter.
Also minor python whitespace cleanup.

The Cockpit ui plugin for setroubleshoot (wip: https://github.com/cockpit-project/cockpit/pull/3962/) would look better if the Messages started with capitalized letters.

Is there a way to preserve translations? I don't want to break all the work that's been done for minor changes.