### PR TITLE
framework: alerts should reflect plugins level

### DIFF
--- a/framework/src/setroubleshoot/analyze.py
+++ b/framework/src/setroubleshoot/analyze.py
@@ -179,7 +179,8 @@ class Analyze(object):
             environment    = environment,
             line_numbers   = avc.audit_event.line_numbers,
             last_seen_date = TimeStamp(avc.audit_event.timestamp),
-            local_id = report_receiver.generate_id()
+            local_id = report_receiver.generate_id(),
+            level = "yellow"
             )
 
         for plugin in self.plugins:
@@ -189,6 +190,13 @@ class Analyze(object):
                     if plugin.level == "white":
                         log_debug("plugin level white, not reporting")
                         return;
+
+                    # "yellow" is default
+                    # "green" overrides "yellow"
+                    # "red" overrides everything
+                    if plugin.level is not None and siginfo.level != "red":
+                        if plugin.level == "red" or plugin.level == "green":
+                            siginfo.level = plugin.level
 
                     if isinstance(report, list):
                         for r in report:

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -134,7 +134,7 @@ system_bus.request_name(dbus_system_bus_name)
 # FIXME: this should be part of ClientNotifier
 def send_alert_notification(siginfo):
     alert=dbus.lowlevel.SignalMessage(dbus_system_object_path, dbus_system_interface, "alert");
-    alert.append("yellow")
+    alert.append(siginfo.level)
     alert.append(siginfo.local_id)
     system_bus.send_message(alert)
 

--- a/framework/src/setroubleshoot/signature.py
+++ b/framework/src/setroubleshoot/signature.py
@@ -306,6 +306,10 @@ class SEFaultSignatureInfo(XmlSerialize):
         for name in self.merge_include:
             setattr(self, name, getattr(siginfo, name))
 
+        # older databases can have an uninitialized level
+        if self.level is None:
+            self.level = siginfo.level
+
     def get_policy_rpm(self):
         return self.environment.policy_rpm;
 


### PR DESCRIPTION
Originally, an alert level was hardcoded to be "yellow" for all. With this
patch, an alert level is created from plugin analysis levels using
following rules:

- "yellow" is default
- "green" overrides "yellow"
- "red" overrides everything

Fixes: https://github.com/fedora-selinux/setroubleshoot/issues/12