### PR TITLE
Extend get_alert() with another 3 return values

### DIFF
--- a/framework/DBUS.md
+++ b/framework/DBUS.md
@@ -52,7 +52,7 @@ see get_all_alerts()
 
 ***
 
-##### get_alert(s: local_id) -> ssiasa(ssssbb)ss
+##### get_alert(s: local_id) -> ssiasa(ssssbb)sss
 
 Return an alert with summary, audit events, fix suggestions
 
@@ -76,6 +76,7 @@ Return an alert with summary, audit events, fix suggestions
  * `report_bug(b)`: True when an alert should be reported to bugzilla
 * `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 * `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+* `level(s)`: "green", "yellow" or "red"
 
 #### Signals
 

--- a/framework/DBUS.md
+++ b/framework/DBUS.md
@@ -52,7 +52,7 @@ see get_all_alerts()
 
 ***
 
-##### get_alert(s: local_id) -> ssiasa(ssssbb)
+##### get_alert(s: local_id) -> ssiasa(ssssbb)ss
 
 Return an alert with summary, audit events, fix suggestions
 
@@ -74,6 +74,8 @@ Return an alert with summary, audit events, fix suggestions
  * `analysis_id(s)`: plugin id. It can be used in `org.fedoraproject.SetroubleshootFixit.run_fix()`
  * `fixable(b)`: True when an alert is fixable by a plugin
  * `report_bug(b)`: True when an alert should be reported to bugzilla
+* `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+* `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 
 #### Signals
 

--- a/framework/DBUS.md
+++ b/framework/DBUS.md
@@ -74,6 +74,8 @@ Return an alert with summary, audit events, fix suggestions
  * `analysis_id(s)`: plugin id. It can be used in `org.fedoraproject.SetroubleshootFixit.run_fix()`
  * `fixable(b)`: True when an alert is fixable by a plugin
  * `report_bug(b)`: True when an alert should be reported to bugzilla
+ * `priority(i)`: An analysis priority. Typically the value is between 1 - 100. Higher value means that the analysis should have higher priority then other
+ with lower values.
 * `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 * `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 * `level(s)`: "green", "yellow" or "red"

--- a/framework/src/setroubleshoot/analyze.py
+++ b/framework/src/setroubleshoot/analyze.py
@@ -179,7 +179,8 @@ class Analyze(object):
             environment    = environment,
             line_numbers   = avc.audit_event.line_numbers,
             last_seen_date = TimeStamp(avc.audit_event.timestamp),
-            local_id = report_receiver.generate_id()
+            local_id = report_receiver.generate_id(),
+            level = "yellow"
             )
 
         for plugin in self.plugins:
@@ -189,6 +190,13 @@ class Analyze(object):
                     if plugin.level == "white":
                         log_debug("plugin level white, not reporting")
                         return;
+
+                    # "yellow" is default
+                    # "green" overrides "yellow"
+                    # "red" overrides everything
+                    if plugin.level is not None and siginfo.level != "red":
+                        if plugin.level == "red" or plugin.level == "green":
+                            siginfo.level = plugin.level
 
                     if isinstance(report, list):
                         for r in report:

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -521,7 +521,7 @@ class SetroubleshootdDBusObject(dbus.service.Object):
 """
         return self._get_all_alerts_since('1970-01-01T00:00:00Z', sender)
 
-    @dbus.service.method(dbus_system_interface, sender_keyword="sender", in_signature='s', out_signature='ssiasa(ssssbb)sss')
+    @dbus.service.method(dbus_system_interface, sender_keyword="sender", in_signature='s', out_signature='ssiasa(ssssbbi)sss')
     def get_alert(self, local_id, sender):
         """
 Return an alert with summary, audit events, fix suggestions
@@ -544,6 +544,7 @@ Return an alert with summary, audit events, fix suggestions
  * `analysis_id(s)`: plugin id. It can be used in `org.fedoraproject.SetroubleshootFixit.run_fix()`
  * `fixable(b)`: True when an alert is fixable by a plugin
  * `report_bug(b)`: True when an alert should be reported to bugzilla
+ * `priority(i)`:  An analysis priority. Typically the value is between 1 - 100.
 * `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 * `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 * `level(s)`: "green", "yellow" or "red"
@@ -571,7 +572,8 @@ Return an alert with summary, audit events, fix suggestions
                 alert.substitute(plugin.get_do_text(avc, args)),
                 plugin.analysis_id,
                 plugin.fixable,
-                plugin.report_bug)
+                plugin.report_bug,
+                plugin.priority)
             )
 
 

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -521,7 +521,7 @@ class SetroubleshootdDBusObject(dbus.service.Object):
 """
         return self._get_all_alerts_since('1970-01-01T00:00:00Z', sender)
 
-    @dbus.service.method(dbus_system_interface, sender_keyword="sender", in_signature='s', out_signature='ssiasa(ssssbb)ss')
+    @dbus.service.method(dbus_system_interface, sender_keyword="sender", in_signature='s', out_signature='ssiasa(ssssbb)sss')
     def get_alert(self, local_id, sender):
         """
 Return an alert with summary, audit events, fix suggestions
@@ -546,6 +546,7 @@ Return an alert with summary, audit events, fix suggestions
  * `report_bug(b)`: True when an alert should be reported to bugzilla
 * `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 * `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+* `level(s)`: "green", "yellow" or "red"
 """
         username = get_identity(self.connection.get_unix_user(sender))
         database = get_host_database()
@@ -575,7 +576,8 @@ Return an alert with summary, audit events, fix suggestions
 
 
         return (alert.local_id, alert.summary(), alert.report_count,
-                audit_events, plugins, str(alert.first_seen_date), str(alert.last_seen_date)
+                audit_events, plugins,
+                str(alert.first_seen_date), str(alert.last_seen_date), alert.level
         )
 
 

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -521,7 +521,7 @@ class SetroubleshootdDBusObject(dbus.service.Object):
 """
         return self._get_all_alerts_since('1970-01-01T00:00:00Z', sender)
 
-    @dbus.service.method(dbus_system_interface, sender_keyword="sender", in_signature='s', out_signature='ssiasa(ssssbb)')
+    @dbus.service.method(dbus_system_interface, sender_keyword="sender", in_signature='s', out_signature='ssiasa(ssssbb)ss')
     def get_alert(self, local_id, sender):
         """
 Return an alert with summary, audit events, fix suggestions
@@ -544,6 +544,8 @@ Return an alert with summary, audit events, fix suggestions
  * `analysis_id(s)`: plugin id. It can be used in `org.fedoraproject.SetroubleshootFixit.run_fix()`
  * `fixable(b)`: True when an alert is fixable by a plugin
  * `report_bug(b)`: True when an alert should be reported to bugzilla
+* `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
+* `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - '%Y-%m-%dT%H:%M:%SZ'
 """
         username = get_identity(self.connection.get_unix_user(sender))
         database = get_host_database()
@@ -573,7 +575,7 @@ Return an alert with summary, audit events, fix suggestions
 
 
         return (alert.local_id, alert.summary(), alert.report_count,
-                audit_events, plugins
+                audit_events, plugins, str(alert.first_seen_date), str(alert.last_seen_date)
         )
 
 

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -134,7 +134,7 @@ system_bus.request_name(dbus_system_bus_name)
 # FIXME: this should be part of ClientNotifier
 def send_alert_notification(siginfo):
     alert=dbus.lowlevel.SignalMessage(dbus_system_object_path, dbus_system_interface, "alert");
-    alert.append("yellow")
+    alert.append(siginfo.level)
     alert.append(siginfo.local_id)
     system_bus.send_message(alert)
 

--- a/framework/src/setroubleshoot/signature.py
+++ b/framework/src/setroubleshoot/signature.py
@@ -306,6 +306,10 @@ class SEFaultSignatureInfo(XmlSerialize):
         for name in self.merge_include:
             setattr(self, name, getattr(siginfo, name))
 
+        # older databases can have an uninitialized level
+        if self.level is None:
+            self.level = siginfo.level
+
     def get_policy_rpm(self):
         return self.environment.policy_rpm;
 


### PR DESCRIPTION
The new signature for get_alert is:

    get_alert(s: local_id) -> ssiasa(ssssbb)sss

Last 3 values are:

* `first_seen_date(s)`: when the alert was seen for the first time, iso8601 format is used - `%Y-%m-%dT%H:%M:%SZ`
* `last_seen_date(s)`: when the alert was seen for the last time, iso8601 format is used - `%Y-%m-%dT%H:%M:%SZ`
* `level(s)`: "green", "yellow" or "red"

Fixes: https://github.com/fedora-selinux/setroubleshoot/issues/20 https://github.com/fedora-selinux/setroubleshoot/issues/19

Note: Based on discussion with @dperpeet I decided to break get_alert() API, and add another 3 values to the end of return values.