### PR TITLE
Fix sshd_root.py setroubleshoot plugin to cover only /root/.ssh path as intended.

### DIFF
--- a/plugins/src/sshd_root.py
+++ b/plugins/src/sshd_root.py
@@ -56,6 +56,7 @@ class plugin(Plugin):
     def analyze(self, avc):
         if avc.matches_source_types(['sshd_t'])           and \
                 avc.matches_target_types(['admin_home_t'])            and \
+                avc.tpath == "/root/.ssh" and \
                 avc.all_accesses_are_in(avc.read_file_perms)  and \
                 avc.has_tclass_in(['file', 'dir']):
 


### PR DESCRIPTION
Previously, if sshd_t and admin_home_t keys were a part of AVC message, sshd_root.py was incorrectly proceeded also for different locations than /root/.ssh.