### PR TITLE
setroubleshoot: Ensure that dbus string param isn't null

### DIFF
--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -579,7 +579,7 @@ Return an alert with summary, audit events, fix suggestions
 
         return (alert.local_id, alert.summary(), alert.report_count,
                 audit_events, plugins,
-                str(alert.first_seen_date), str(alert.last_seen_date), alert.level
+                str(alert.first_seen_date), str(alert.last_seen_date), alert.level or ''
         )
 
 


### PR DESCRIPTION
An alert's level can be None, but DBUS doesn't allow that for string parameters.

Just using `str()` here isn't what we want, since `str(None)` is `'None'`