### PR TITLE
Improve work with modules created by setoubleshoot plugin's suggestion

### DIFF
--- a/plugins/src/catchall.py
+++ b/plugins/src/catchall.py
@@ -55,7 +55,7 @@ class plugin(Plugin):
     then_text = _('You should report this as a bug.\nYou can generate a local policy module to allow this access.')
     do_text = _("""Allow this access for now by executing:
 # ausearch -c $SOURCE --raw | audit2allow -M my-$SOURCE
-# semodule -i my-$SOURCE.pp""")
+# semodule -X 300 -i my-$SOURCE.pp""")
 
     def __init__(self):
         Plugin.__init__(self, __name__)

--- a/plugins/src/catchall.py
+++ b/plugins/src/catchall.py
@@ -54,8 +54,8 @@ class plugin(Plugin):
 
     then_text = _('You should report this as a bug.\nYou can generate a local policy module to allow this access.')
     do_text = _("""Allow this access for now by executing:
-# ausearch -c $SOURCE --raw | audit2allow -M mypol
-# semodule -i mypol.pp""")
+# ausearch -c $SOURCE --raw | audit2allow -M my-$SOURCE
+# semodule -i my-$SOURCE.pp""")
 
     def __init__(self):
         Plugin.__init__(self, __name__)

--- a/plugins/src/leaks.py
+++ b/plugins/src/leaks.py
@@ -42,7 +42,7 @@ class plugin(Plugin):
     if_text = _('you want to ignore $SOURCE_BASE_PATH trying to $ACCESS access the $TARGET_BASE_PATH $TARGET_CLASS, because you believe it should not need this access.')
     then_text = _('You should report this as a bug.  \nYou can generate a local policy module to dontaudit this access.')
     do_text = _("""# ausearch -x $SOURCE_PATH --raw | audit2allow -D -M my-$SOURCE
-# semodule -i my-$SOURCE.pp""")
+# semodule -X 300 -i my-$SOURCE.pp""")
 
     def __init__(self):
         Plugin.__init__(self,__name__)

--- a/plugins/src/leaks.py
+++ b/plugins/src/leaks.py
@@ -41,8 +41,8 @@ class plugin(Plugin):
 
     if_text = _('you want to ignore $SOURCE_BASE_PATH trying to $ACCESS access the $TARGET_BASE_PATH $TARGET_CLASS, because you believe it should not need this access.')
     then_text = _('You should report this as a bug.  \nYou can generate a local policy module to dontaudit this access.')
-    do_text = _("""# ausearch -x $SOURCE_PATH --raw | audit2allow -D -M mypol
-# semodule -i mypol.pp""")
+    do_text = _("""# ausearch -x $SOURCE_PATH --raw | audit2allow -D -M my-$SOURCE
+# semodule -i my-$SOURCE.pp""")
 
     def __init__(self):
         Plugin.__init__(self,__name__)


### PR DESCRIPTION
There are two improvements:

* mypol.pp is not suggested anymore. The new module format is my-<command>.pp where <command> is based on comm= field from the audit event.

* Plugins suggest to use "semodule -X 300"  to set a priority for setroubleshoot modules different  than the default value - 400.

e.g.
    
    # semodule --list=full | grep 300
    300 my-cat            pp         
    300 my-sshd           pp   