### PR TITLE
setroubleshoot: Fix sealert (+ catchall pluging) message for capability2

### DIFF
--- a/framework/src/setroubleshoot/signature.py
+++ b/framework/src/setroubleshoot/signature.py
@@ -212,6 +212,7 @@ class_dict['process'] = _("process")
 class_dict['filesystem'] = _("filesystem")
 class_dict['node'] = _("node")
 class_dict['capability'] = _("capability")
+class_dict['capability2'] = _("capability2")
 
 def translate_class(tclass):
     if tclass in list(class_dict.keys()):
@@ -447,7 +448,7 @@ class SEFaultSignatureInfo(XmlSerialize):
         if self.tclass == "process":
             return P_(_("SELinux is preventing %s from using the %s access on a process."), _("SELinux is preventing %s from using the '%s' accesses on a process."), len(self.sig.access)) % (self.spath, ", ".join(self.sig.access))
 
-        if self.tclass == "capability":
+        if self.tclass in ["capability", "capability2"]:
             return P_(_("SELinux is preventing %s from using the %s capability."), _("SELinux is preventing %s from using the '%s' capabilities."), len(self.sig.access)) % (self.spath, ", ".join(self.sig.access))
         if self.tpath == "(null)":
             return P_(_("SELinux is preventing %s from %s access on the %s labeled %s."), _("SELinux is preventing %s from '%s' accesses on the %s labeled %s."), len(self.sig.access)) % (self.spath, ", ".join(self.sig.access), translate_class(self.tclass), self.tcontext.type)

--- a/plugins/src/catchall.py
+++ b/plugins/src/catchall.py
@@ -48,7 +48,7 @@ class plugin(Plugin):
     def get_if_text(self, avc, args):
         if args[1] == "process":
             return _('you believe that $SOURCE_BASE_PATH should be allowed $ACCESS access on processes labeled $TARGET_TYPE by default.')
-        if args[1] == "capability":
+        if args[1] in ["capability", "capability2"]:
             return _('you believe that $SOURCE_BASE_PATH should have the $ACCESS capability by default.')
         return _('you believe that $SOURCE_BASE_PATH should be allowed $ACCESS access on the $TARGET_BASE_PATH $TARGET_CLASS by default.')
 


### PR DESCRIPTION
Sealert didn't know "capability2" class which caused capability2 
denials (e.g. block_suspend) to be reported as "access" denials.

Catchall plugin was changed accordingly.

BZ: 1360392