### PR TITLE
setroubleshoot: Fix "list all alerts" in sealert gui

### DIFF
--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -291,7 +291,7 @@ class BrowserApplet:
         tmsort = Gtk.TreeModelSort(model = self.liststore)
 
         cols = [_("#"), _("Source Process"), _("Attempted Access"), _("On this"), _("Occurred"), _("Status")]
-#        self.treeview.set_model(tmsort)
+        self.treeview.set_model(tmsort)
         x = 0
         for c in cols:
             cell = Gtk.CellRendererText()


### PR DESCRIPTION
There was a typo in commit "044d6fbb" disabling model for treeview
in "alert_list_window" (list of all alerts). This caused the list
of all alerts to appear empty.

Fixes:
   https://bugzilla.redhat.com/show_bug.cgi?id=1370272
   https://bugzilla.redhat.com/show_bug.cgi?id=1332485

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>