### PR TITLE
framework: fix plugin handling

### DIFF
--- a/framework/src/setroubleshoot/Plugin.py
+++ b/framework/src/setroubleshoot/Plugin.py
@@ -94,6 +94,9 @@ o
         self.fixable = False
         self.button_text = ""
         self.report_bug = False
+
+    def init_args(self, args):
+        pass
         
     def get_problem_description(self, avc, args):
         return self.if_text

--- a/framework/src/setroubleshoot/Plugin.py
+++ b/framework/src/setroubleshoot/Plugin.py
@@ -99,7 +99,7 @@ o
         pass
         
     def get_problem_description(self, avc, args):
-        return self.if_text
+        return self.problem_description
 
     def get_if_text(self, avc, args):
         return self.if_text

--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -569,7 +569,7 @@ class BrowserApplet:
            msg = ""
            for i in plugin.get_problem_description(avc, args).split("\n"):
                msg += alert.substitute(i.strip()) + "\n"
-           message += html_to_text(msg)
+           message += html_to_text(msg) + "\n\n"
            message += alert.substitute(_("If ") + plugin.get_if_text(avc, args)) + "\n"
            message += alert.substitute(plugin.get_then_text(avc, args)) + "\n"
            message += alert.substitute(plugin.get_do_text(avc, args)) + "\n"

--- a/framework/src/setroubleshoot/signature.py
+++ b/framework/src/setroubleshoot/signature.py
@@ -467,6 +467,7 @@ class SEFaultSignatureInfo(XmlSerialize):
                 for p  in self.plugins:
                     if solution.analysis_id == p.analysis_id:
                         total_priority += p.priority
+                        p.init_args(tuple(solution.args))
                         plugins.append((p, tuple(solution.args)))
                         break
 


### PR DESCRIPTION
Fix get_problem_description.
Add "init_args" function to "Plugin" class which is executed
after reloading plugins in sealert (get_plugins). This allows
for changing "fixable" and "report_bug" variables after plugin
analysis.