### PR TITLE
framework: change "check_for_man" return value upon failure

### DIFF
--- a/framework/src/setroubleshoot/Plugin.py
+++ b/framework/src/setroubleshoot/Plugin.py
@@ -133,4 +133,4 @@ o
         man_page = name.split("_")[0] + "_selinux"
         if os.path.isfile("/usr/share/man/man8/%s.8.gz" % man_page):
             return man_page
-        return None
+        return ""


### PR DESCRIPTION
check_for_man is designed to be used by plugins, which might "save"
the return value in "args" using "report" (viz. checkall_boolean).
In that case None is changed to string "None", causing hard to find
bugs when recognising non-existent man page.