### PR TITLE
framework: fix sealert crash when setroubleshootd fails to start

### DIFF
--- a/framework/src/sealert
+++ b/framework/src/sealert
@@ -682,6 +682,10 @@ if __name__ == '__main__':
             except ValueError as e:
                 print(e, file=sys.stderr)
                 sys.exit(3)
+            except dbus.exceptions.DBusException as e:
+                print("Unable to establish connection to setroubleshoot daemon!\n" +
+                      "Check output of 'journalctl -t setroubleshoot' for more details.")
+                sys.exit(3)
 
             sys.exit()
         elif invocation_style == 'analyze':


### PR DESCRIPTION
Make sure the dbus connection to setroubleshootd is correctly established.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1405003

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>