### PR TITLE
plugins/catchall_boolean: fix import of boolean_desc

### DIFF
--- a/plugins/src/catchall_boolean.py
+++ b/plugins/src/catchall_boolean.py
@@ -27,7 +27,7 @@ _=translation.gettext
 
 from setroubleshoot.util import *
 from setroubleshoot.Plugin import Plugin
-import seobject
+import sepolicy
 
 class plugin(Plugin):
     summary = _('''
@@ -57,7 +57,7 @@ class plugin(Plugin):
         self.level = "yellow"
 
     def get_if_text(self, avc, args):
-        txt=seobject.boolean_desc(args[0])
+        txt=sepolicy.boolean_desc(args[0])
         if not isinstance(txt, six.text_type):
             txt=six.text_type(txt, encoding="utf8")
         return _("you want to %s") % (txt[0].lower() + txt[1:])


### PR DESCRIPTION
Commit
https://github.com/fedora-selinux/selinux/commit/b43991f9135e5422fd1058ecbd427ae6c9283eab
removed direct import of boolean_desc to seobject.
Import boolean_desc directly from sepolicy.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1444549

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>