### PR TITLE
Fix missing margins on Troubleshoot window

### DIFF
--- a/framework/gui/browser.glade
+++ b/framework/gui/browser.glade
@@ -629,6 +629,8 @@ John Dennis &lt;jdennis@redhat.com&gt;</property>
                     <property name="can_focus">False</property>
                     <property name="row_spacing">3</property>
                     <property name="column_spacing">3</property>
+                    <property name="margin_left">16</property>
+                    <property name="margin_right">12</property>
                     <child>
                       <placeholder/>
                     </child>


### PR DESCRIPTION
After clicking the Troubleshoot buttons, the text on the left (if-text) and the buttons on the right (Report Details, Report Bug) are glued to the outside window frame.

This fix adds margins both on the left and on the right side of the vindow triggered by the Troubleshoot button.