### PR TITLE
Add and install missing style.css

### DIFF
--- a/framework/gui/Makefile.am
+++ b/framework/gui/Makefile.am
@@ -18,6 +18,7 @@ GUI_FILES =              \
 	bug_report.glade        \
 	fail_dialog.glade    \
 	success_dialog.glade \
+	style.css		\
 	$(NULL)
 
 icondir = /usr/share/icons/hicolor/

--- a/framework/gui/style.css
+++ b/framework/gui/style.css
@@ -1,0 +1,17 @@
+.toggle.green {
+  border-image: none;
+  background-image: none;
+  background-color: green;
+}
+
+.toggle.red {
+  border-image: none;
+  background-image: none;
+  background-color: red;
+}
+
+.toggle.yellow {
+  border-image: none;
+  background-image: none;
+  background-color: yellow;
+}

--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -441,29 +441,19 @@ class BrowserApplet:
         if not if_text:
             return
 
-        black = Gdk.Color(0,0,0)
-        if plugin.level == "red":
-            color = Gdk.Color(65535,0,0)
-        elif plugin.level == "yellow":
-            color = Gdk.Color(65535,65525,0)
-        elif plugin.level == "green":
-            color = Gdk.Color(0,65535,0)
-
         sev_toggle = Gtk.ToggleButton()
-#        sev_toggle.set_size_request(20,20)
-        sev_toggle.modify_bg(Gtk.StateType.PRELIGHT, color)
-        sev_toggle.modify_bg(Gtk.StateType.SELECTED, black)
-        sev_toggle.modify_bg(Gtk.StateType.ACTIVE, color)
-        sev_toggle.modify_bg(Gtk.StateType.NORMAL, color)
+        if plugin.level == "red":
+            sev_toggle.get_style_context().add_class("red")
+        elif plugin.level == "yellow":
+            sev_toggle.get_style_context().add_class("yellow")
+        elif plugin.level == "green":
+            sev_toggle.get_style_context().add_class("green")
 
-        sev_toggle.modify_fg(Gtk.StateType.PRELIGHT, color)
-        sev_toggle.modify_fg(Gtk.StateType.SELECTED, black)
-        sev_toggle.modify_fg(Gtk.StateType.ACTIVE, black)
-        sev_toggle.modify_fg(Gtk.StateType.NORMAL, color)
-
-        sev_toggle.modify_base(Gtk.StateType.SELECTED, black)
-
-        sev_toggle.set_alignment(0.5, 0.0)
+        cssProvider = Gtk.CssProvider()
+        cssProvider.load_from_path('/usr/share/setroubleshoot/gui/style.css')
+        screen = Gdk.Screen.get_default()
+        styleContext = Gtk.StyleContext()
+        styleContext.add_provider_for_screen(screen, cssProvider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 
         self.toggles.append(sev_toggle)
         sev_toggle.show()


### PR DESCRIPTION
The file style.css has been omitted from previous commit, preventing the fix from working. This fixes the issue and enables the button colors to work properly.