### PR TITLE
Resize all solutions panels horizontally

### DIFF
--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -503,6 +503,7 @@ class BrowserApplet:
         then_scroll.set_sensitive(False)
         then_scroll.set_size_request(450, 90)
         then_scroll.set_hexpand(True)
+        then_scroll.set_vexpand(True)
         # self.table.resize(rows, cols) GtkGrid resize automatically
         sev_toggle.connect("toggled", self.on_sev_togglebutton_activated, rows)
 #        col = 0


### PR DESCRIPTION
After clicking the Troubleshoot button, the height of the proposed solutions has been too small, hiding parts of the then-text. Scrolling has been required to read the whole then-text, even though there was still vertical space inside the window that allowed more text to be displayed.

This fix allows dynamic (horizontal) resize of all solution panels, depending on the actual window size.