### PR TITLE
framework: Fix semi-translated messages

### DIFF
--- a/framework/src/run_cmd.py
+++ b/framework/src/run_cmd.py
@@ -23,7 +23,6 @@ __all__ = ["RunCmdGUI",
 import syslog
 import os
 import signal
-#import sys
 
 def wait_status(status):
     exit_status = (status >> 8) & 0xFF
@@ -38,10 +37,14 @@ import gobject
 
 if __name__ == "__main__":
     import gettext
+    import sys
     from setroubleshoot.config import parse_config_setting, get_config
+    kwargs = {}
+    if sys.version_info < (3,):
+        kwargs['unicode'] = True
     gettext.install(domain    = get_config('general', 'i18n_text_domain'),
-                    unicode = True,
-		    localedir = get_config('general', 'i18n_locale_dir'))
+                    localedir = get_config('general', 'i18n_locale_dir'),
+                    **kwargs)
 
 #------------------------------------------------------------------------
 

--- a/framework/src/setroubleshoot/Plugin.py
+++ b/framework/src/setroubleshoot/Plugin.py
@@ -20,12 +20,16 @@
 #
 
 import gettext
-translation=gettext.translation('setroubleshoot-plugins', fallback=True)
+from setroubleshoot.config import parse_config_setting, get_config
+
+translation=gettext.translation(domain    = get_config('general', 'i18n_text_domain'),
+                                localedir = get_config('general', 'i18n_locale_dir'),
+                                fallback  = True)
 
 try:
-    _ = translation.ugettext # This raises exception in Python3, succ. in Py2
+    _ = translation.ugettext # Unicode version of gettext for Py2
 except AttributeError:
-     _ = translation.gettext # Python3
+    _ = translation.gettext # Python3 (uses unicode by default)
 
 from setroubleshoot.signature import *
 from setroubleshoot.util import *

--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -29,15 +29,18 @@ from setroubleshoot.config import parse_config_setting, get_config
 import six
 import sys
 domain = get_config('general', 'i18n_text_domain')
+localedir = get_config('general', 'i18n_locale_dir')
 
 kwargs = {}
 if sys.version_info < (3,):
     kwargs['unicode'] = True
 gettext.install(domain    = domain,
-                localedir = get_config('general', 'i18n_locale_dir'),
+                localedir = localedir,
                 **kwargs)
 
-translation=gettext.translation(domain, fallback=True)
+translation=gettext.translation(domain    = domain,
+                                localedir = localedir,
+                                fallback=True)
 
 rows = 1
 

--- a/framework/src/setroubleshoot/errcode.py
+++ b/framework/src/setroubleshoot/errcode.py
@@ -17,12 +17,17 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #
 import gettext
-translation=gettext.translation('setroubleshoot-plugins', fallback=True)
+from setroubleshoot.config import parse_config_setting, get_config
+
+translation=gettext.translation(domain    = get_config('general', 'i18n_text_domain'),
+                                localedir = get_config('general', 'i18n_locale_dir'),
+                                fallback  = True)
 
 try:
-    _ = translation.ugettext # This raises exception in Python3, succ. in Py2
+    _ = translation.ugettext # Unicode version of gettext for Py2
 except AttributeError:
-    _ = translation.gettext # Python3
+    _ = translation.gettext # Python3 (uses unicode by default)
+
 
 __all__ = [
     'ProgramError',

--- a/framework/src/setroubleshoot/server.py
+++ b/framework/src/setroubleshoot/server.py
@@ -48,14 +48,17 @@ import systemd.journal
 from setroubleshoot.config import parse_config_setting, get_config
 
 domain = get_config('general', 'i18n_text_domain')
+localedir = get_config('general', 'i18n_locale_dir')
 kwargs = {}
 if sys.version_info < (3,):
     kwargs['unicode'] = True
 gettext.install(domain    = domain,
-                localedir = get_config('general', 'i18n_locale_dir'),
+                localedir = localedir,
                 **kwargs)
 
-translation=gettext.translation(domain, fallback=True)
+translation=gettext.translation(domain    = domain,
+                                localedir = localedir,
+                                fallback  = True)
 
 try:
     _ = translation.ugettext # This raises exception in Python3, succ. in Py2

--- a/framework/src/setroubleshoot/signature.py
+++ b/framework/src/setroubleshoot/signature.py
@@ -24,15 +24,20 @@ from __future__ import print_function
 import six
 import syslog
 from subprocess import *
-import gettext
 from six.moves import range
 from functools import cmp_to_key
-translation=gettext.translation('setroubleshoot-plugins', fallback=True)
+import gettext
+from setroubleshoot.config import parse_config_setting, get_config
+
+translation=gettext.translation(domain    = get_config('general', 'i18n_text_domain'),
+                                localedir = get_config('general', 'i18n_locale_dir'),
+                                fallback  = True)
 
 try:
-    _ = translation.ugettext # This raises exception in Python3, succ. in Py2
+    _ = translation.ugettext # Unicode version of gettext for Py2
 except AttributeError:
-    _ = translation.gettext # Python3
+    _ = translation.gettext # Python3 (uses unicode by default)
+
 
 __all__ = [
            'SignatureMatch',
@@ -56,10 +61,8 @@ __all__ = [
            ]
 
 if __name__ == "__main__":
-    import gettext
-    from setroubleshoot.config import parse_config_setting, get_config
     gettext.install(domain    = get_config('general', 'i18n_text_domain'),
-		    localedir = get_config('general', 'i18n_locale_dir'))
+		            localedir = get_config('general', 'i18n_locale_dir'))
 
 from gettext import ngettext as P_
 from setroubleshoot.config import get_config


### PR DESCRIPTION
Gettext domains were hardcoded in some modules (pointing to translations
for setroubleshoot plugins) which caused semi-translated messages.
Remove hardcoded gettext domain and use value from config file instead.

Note:
   gettext.install sets the "_" function into global builtins namespace,
   as opposed "manually" setting "_" with gettext.translation(...).gettext,
   which only affects given module. Therefore in some cases both methods
   were left in use.

Fixes:
   https://bugzilla.redhat.com/show_bug.cgi?id=1332126

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>