### PR TITLE
Increase the space for suggested solutions

### DIFF
--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -180,8 +180,8 @@ class BrowserApplet:
     def __init__(self, username=None, server=None, list=False, domain=None):
         self.RECT_SIZE = 20
         size = Gdk.Screen().get_default().get_monitor_geometry(0)
-        self.width = min(900, int(size.width * .90))
-        self.height = min(500, int(size.height * .90))
+        self.width = min(1350, int(size.width * .90))
+        self.height = min(750, int(size.height * .90))
 
         self.read_config()
         builder = Gtk.Builder()


### PR DESCRIPTION
After clicking the 'Troubleshoot' button, the user had to manually enlarge the
window size to see the solutions suggested by the plugins.

This patch doubles the original window size to increase the amouth of
information displayed to the user. Generally, all of the information is shown,
even for larger texts.

Environment used for the test
- setroubleshoot-3.3.13
- setroubleshoot-plugins-3.3.8
- Fedora 26