### PR TITLE
Fix allowed_target_types and change plugins accordingly

### DIFF
--- a/framework/src/setroubleshoot/audit_data.py
+++ b/framework/src/setroubleshoot/audit_data.py
@@ -677,7 +677,10 @@ class AVC:
         all_attributes = get_all_attributes()
         all_attributes.sort()
         allowed_types = []
-        wtypes = [x[TARGET] for x in [y for y in search([ALLOW], {SOURCE: self.scontext.type, CLASS: self.tclass, PERMS: self.access}) if y["enabled"]]]
+        allow_rules = search([ALLOW], {SOURCE: self.scontext.type, CLASS: self.tclass, PERMS: self.access})
+        if not allow_rules:
+            return []
+        wtypes = [x[TARGET] for x in [y for y in allow_rules if y["enabled"]]]
         types = wtypes
         for t in types:
             if t in all_attributes:

--- a/plugins/src/bind_ports.py
+++ b/plugins/src/bind_ports.py
@@ -62,9 +62,9 @@ class plugin(Plugin):
     def analyze(self, avc):
         if (avc.matches_target_types(['hi_reserved_port_t','reserved_port_t', 'port_t', 'unreserved_port_t', ]) and
                 avc.has_any_access_in(['name_bind'])):
-                # MATCH
-            target_types = ", ".join(avc.allowed_target_types())
-            if target_types != "":
-                return self.report((avc.tclass.split("_")[0], target_types))
+            # MATCH
+            allowed_types = avc.allowed_target_types()
+            if allowed_types:
+                return self.report((avc.tclass.split("_")[0], ", ".join(allowed_types))
 
         return None

--- a/plugins/src/catchall_labels.py
+++ b/plugins/src/catchall_labels.py
@@ -50,5 +50,7 @@ restorecon -v '$FIX_TARGET_PATH'
     def analyze(self, avc):
         if (avc.syscall != 'execve' and avc.matches_target_types(['file_t', 'unlabeled_t', 'usr_t', 'etc_t', 'mnt_t', 'var_t', 'var_lib_t', 'default_t']) and
                 avc.has_tclass_in(['dir', 'file', 'lnk_file', 'sock_file'])):
-            return self.report(avc.allowed_target_types())
+            allowed_types = avc.allowed_target_types()
+            if allowed_types:
+                return self.report(allowed_types)
         return None

--- a/plugins/src/connect_ports.py
+++ b/plugins/src/connect_ports.py
@@ -61,7 +61,8 @@ class plugin(Plugin):
         if (avc.matches_target_types(['hi_reserved_port_t','reserved_port_t', 'port_t', 'unreserved_port_t' ]) and
             avc.has_any_access_in(['name_connect'])):
             # MATCH
-            target_types = ", ".join(avc.allowed_target_types())
-            return self.report( (avc.tclass.split("_")[0], target_types))
+            allowed_types = avc.allowed_target_types()
+            if allowed_types:
+                return self.report( (avc.tclass.split("_")[0], ", ".join(allowed_types)))
 
         return None


### PR DESCRIPTION
allowed_target_types causes exception in case no rules where found by search([ALLOW], {SOURCE: self.scontext.type, CLASS: self.tclass, PERMS: self.access})
This used to crash plugins that would use it (and generate error message in audit log), therefore those plugins need to be changed to exit when no allowed_target_types are found.

 Resolves: rhbz#1460642, rhbz#1460648