### PR TITLE
plugins: Handle no "allowed_target_types" properly

### DIFF
--- a/plugins/src/bind_ports.py
+++ b/plugins/src/bind_ports.py
@@ -62,9 +62,9 @@ class plugin(Plugin):
     def analyze(self, avc):
         if (avc.matches_target_types(['hi_reserved_port_t','reserved_port_t', 'port_t', 'unreserved_port_t', ]) and
                 avc.has_any_access_in(['name_bind'])):
-                # MATCH
-            target_types = ", ".join(avc.allowed_target_types())
-            if target_types != "":
-                return self.report((avc.tclass.split("_")[0], target_types))
+            # MATCH
+            allowed_types = avc.allowed_target_types()
+            if allowed_types:
+                return self.report((avc.tclass.split("_")[0], ", ".join(allowed_types))
 
         return None

--- a/plugins/src/catchall_labels.py
+++ b/plugins/src/catchall_labels.py
@@ -50,5 +50,7 @@ restorecon -v '$FIX_TARGET_PATH'
     def analyze(self, avc):
         if (avc.syscall != 'execve' and avc.matches_target_types(['file_t', 'unlabeled_t', 'usr_t', 'etc_t', 'mnt_t', 'var_t', 'var_lib_t', 'default_t']) and
                 avc.has_tclass_in(['dir', 'file', 'lnk_file', 'sock_file'])):
-            return self.report(avc.allowed_target_types())
+            allowed_types = avc.allowed_target_types()
+            if allowed_types:
+                return self.report(allowed_types)
         return None

--- a/plugins/src/connect_ports.py
+++ b/plugins/src/connect_ports.py
@@ -61,7 +61,8 @@ class plugin(Plugin):
         if (avc.matches_target_types(['hi_reserved_port_t','reserved_port_t', 'port_t', 'unreserved_port_t' ]) and
             avc.has_any_access_in(['name_connect'])):
             # MATCH
-            target_types = ", ".join(avc.allowed_target_types())
-            return self.report( (avc.tclass.split("_")[0], target_types))
+            allowed_types = avc.allowed_target_types()
+            if allowed_types:
+                return self.report( (avc.tclass.split("_")[0], ", ".join(allowed_types)))
 
         return None


### PR DESCRIPTION
These plugins are not helpful in case there are no allowed_target_types.

Resolves: rhbz#1460642, rhbz#1460648

allowed_target_types works properly on Fedora, therefore only pushing this patch (as opposed to 2 patches on stable branch)