### PR TITLE
framework: Fix translation of hex values in AVCs

### DIFF
--- a/framework/src/setroubleshoot/util.py
+++ b/framework/src/setroubleshoot/util.py
@@ -159,7 +159,16 @@ def audit_msg_decode(msg):
         decoded = match.group(1)
     else:
         try:
-            decoded = msg.decode('hex')
+            if sys.version_info[0] < 3:
+                # Produces normal string instead of unicode string which is not
+                # accepted by libselinux functions.
+                # This means that len(path) will return inaccurate results when
+                # the string contains special characters. Also individual bytes
+                # of path may not be printable.
+                decoded = msg.decode('hex')
+            else:
+                # produces str in python 3 and unicode string in python 2
+                decoded = bytearray.fromhex(msg).decode('utf-8')
         except:
             decoded = msg
     return decoded


### PR DESCRIPTION
Audit encloses plain text values of path, name or exe fields in double
quotes to distinguish them from hex encoded values. Use this instead of
trying to hex-translate all values. The translation is done immediately
after parsing the AVC, hence all other attempts to hex translate could
be removed.

Use bytearray.fromhex(path).decode('utf-8') instead of str.decode('hex')
because it handles non-ASCII characters correctly and works on both
python 2 and 3.

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>