### PR TITLE
framework: Fix AVC.__typeMatch to handle aliases properly

### DIFF
--- a/framework/src/setroubleshoot/audit_data.py
+++ b/framework/src/setroubleshoot/audit_data.py
@@ -732,9 +732,18 @@ class AVC:
         return False
 
     def __typeMatch(self, context, type_list):
+        # get array of context type and it's aliases
+        try:
+            _info = info(TYPE, context.type)[0]
+            ctypes = _info.get('aliases', [])
+            ctypes.append(_info['name'])
+        except (RuntimeError, IndexError):
+            ctypes = [context.type]
+
         for type in type_list:
-            if re.match(type, context.type):
-                return True
+            for t in ctypes:
+                if re.match(type, t):
+                    return True
         return False
 
     def matches_source_types(self, type_list):


### PR DESCRIPTION
Fixes:
   Aliases where not evaluated properly when used as arguments
   of avc.matches_*_types()
   As a result plugins where no longer triggered if a type they
   specified was transformed to an alias.

This change is already part of "stable" branch.