### PR TITLE
framework/browser: Check return value of Gdk.Screen().get_default()

### DIFF
--- a/framework/src/setroubleshoot/browser.py
+++ b/framework/src/setroubleshoot/browser.py
@@ -186,10 +186,14 @@ class BrowserApplet:
 
     def __init__(self, username=None, server=None, list=False, domain=None):
         self.RECT_SIZE = 20
-        size = Gdk.Screen().get_default().get_monitor_geometry(0)
-        self.width = min(1350, int(size.width * .90))
-        self.height = min(750, int(size.height * .90))
-
+        default_screen = Gdk.Screen().get_default()
+        if default_screen:
+            size = default_screen.get_monitor_geometry(0)
+            self.width = min(1350, int(size.width * .90))
+            self.height = min(750, int(size.height * .90))
+        else:
+            print("ERROR (Gdk): couldn't connect to display.", file=sys.stderr)
+            exit(1)
         self.read_config()
         builder = Gtk.Builder()
         builder.set_translation_domain(domain)
@@ -464,7 +468,8 @@ class BrowserApplet:
         cssProvider.load_from_path('/usr/share/setroubleshoot/gui/style.css')
         screen = Gdk.Screen.get_default()
         styleContext = Gtk.StyleContext()
-        styleContext.add_provider_for_screen(screen, cssProvider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+        if screen:
+            styleContext.add_provider_for_screen(screen, cssProvider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 
         self.toggles.append(sev_toggle)
         sev_toggle.show()


### PR DESCRIPTION
Gdk.Screen().get_default() can return None. Add fallback in case this happens.

Fixes:
 Traceback (most recent call last):
  File "/usr/bin/sealert", line 659, in <module>
    run_as_dbus_service(username)
  File "/usr/bin/sealert", line 118, in run_as_dbus_service
    app = SEAlert(user, dbus_service.presentation_manager, watch_setroubleshootd=True)
  File "/usr/bin/sealert", line 351, in __init__
    self.browser = BrowserApplet(self.username, self.alert_client, domain=domain)
  File "/usr/lib/python3.6/site-packages/setroubleshoot/browser.py", line 182, in __init__
    size = Gdk.Screen().get_default().get_monitor_geometry(0)
  AttributeError: 'NoneType' object has no attribute 'get_monitor_geometry'

Note: Sealert still crashes even with the fallback (seems to be an issue in GTK),
      so it might be better to just exit (until it is fixed).

  Unable to init server: Could not connect: Connection refused
  Unable to init server: Could not connect: Connection refused

  (setroubleshoot:325567): Gtk-CRITICAL **: 10:52:37.715: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed
  (setroubleshoot:325567): Gtk-CRITICAL **: 10:52:37.715: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed
  (setroubleshoot:325567): Gtk-CRITICAL **: 10:52:37.715: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed
  [1]    325567 segmentation fault (core dumped)  sealert -s