### PR TITLE
framework: Fix plugin exception reporting

### DIFF
--- a/framework/src/setroubleshoot/analyze.py
+++ b/framework/src/setroubleshoot/analyze.py
@@ -215,7 +215,7 @@ class Analyze(object):
                 print(e, file=sys.stderr)
                 syslog.syslog(syslog.LOG_ERR, "Plugin Exception %s " % plugin.analysis_id)
                 (v1, v2, v3) = sys.exc_info()
-                log_debug(join(traceback.format_tb(v3)))
+                log_debug('\n'.join(traceback.format_tb(v3)))
                 self.plugins.remove(plugin)
 
         report_receiver.report_problem(siginfo)


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/setroubleshoot/analyze.py", line 647, in <lambda>
    self.idle_proc_id = GLib.idle_add(lambda: next(task_generator))
  File "/usr/lib/python3.6/site-packages/setroubleshoot/analyze.py", line 680, in task
    self.close()
  File "/usr/lib/python3.6/site-packages/setroubleshoot/analyze.py", line 668, in close
    self.avc_event_handler(audit_event)
  File "/usr/lib/python3.6/site-packages/setroubleshoot/analyze.py", line 709, in avc_event_handler
    self.analyzer.analyze_avc(avc, self.report_receiver, False)
  File "/usr/lib/python3.6/site-packages/setroubleshoot/analyze.py", line 218, in analyze_avc
    log_debug(join(traceback.format_tb(v3)))
NameError: name 'join' is not defined